### PR TITLE
Show published date in ProseLayout (excluding weeknotes)

### DIFF
--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -1,18 +1,40 @@
 ---
 import Layout from "./Layout.astro";
-const { frontmatter } = Astro.props;
+const { frontmatter, hidePublishedOn } = Astro.props;
 /** TODO: different formats for different kinds of pages
 - one-off pages should have: flex flex-col items-center justify-center
 - long form pages (like my current work page, random notes dumps, etc, should have less margins and left justification
 -  blog posts also should be treated differently.
   */
+
+const publishedOn: Date | undefined = frontmatter?.publishedOn;
+const showPublishedOn = !hidePublishedOn && publishedOn instanceof Date;
+const publishedOnFormatted = showPublishedOn
+  ? publishedOn.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    })
+  : null;
+const publishedOnIso = showPublishedOn ? publishedOn.toISOString() : undefined;
 ---
 
 <Layout
   class="min-w-screen min-h-screen flex justify-center my-12 md:my-16 prose md:prose-lg ld:prose-xl prose-stone prose-headings:font-literata prose-headings:font-bold"
 >
   <div class="mx-8 md:w-1/2 leading-6 pb-8">
-    {frontmatter?.title && <h1>{frontmatter.title}</h1>}
+    {
+      frontmatter?.title && (
+        <header class="title-block">
+          <h1>{frontmatter.title}</h1>
+          {publishedOnFormatted && (
+            <time class="published-on" datetime={publishedOnIso}>
+              {publishedOnFormatted}
+            </time>
+          )}
+        </header>
+      )
+    }
     <slot />
     {
       frontmatter?.tags && frontmatter.tags.length > 0 && (
@@ -29,6 +51,24 @@ const { frontmatter } = Astro.props;
 </Layout>
 
 <style>
+  .title-block {
+    margin-bottom: 2rem;
+  }
+
+  .title-block :global(h1) {
+    margin-bottom: 0.25rem;
+  }
+
+  .published-on {
+    display: block;
+    font-size: 0.85rem;
+    font-style: italic;
+    font-variant: small-caps;
+    letter-spacing: 0.03em;
+    color: var(--tw-prose-captions, rgba(0, 0, 0, 0.55));
+    opacity: 0.7;
+  }
+
   .tags {
     margin-top: 2rem;
     display: flex;

--- a/src/pages/weeknotes/[...slug].astro
+++ b/src/pages/weeknotes/[...slug].astro
@@ -15,6 +15,6 @@ const { weeknote } = Astro.props;
 const { Content } = await render(weeknote);
 ---
 
-<ProseLayout frontmatter={weeknote.data}>
+<ProseLayout frontmatter={weeknote.data} hidePublishedOn>
   <Content />
 </ProseLayout>


### PR DESCRIPTION
Renders the publishedOn frontmatter date as a styled <time> element
under the title. Weeknotes opt out via a hidePublishedOn prop.

https://claude.ai/code/session_01CTRsuVyLRRhgUGXBj96EyE