### PR TITLE
Add reading time indicator for long blog and weeknote posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "astro": "^5.7.5",
     "astro-icon": "^1.1.5",
     "markdown-it": "^14.1.0",
+    "reading-time": "^1.5.0",
     "sanitize-html": "^2.17.0",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       markdown-it:
         specifier: ^14.1.0
         version: 14.1.0
+      reading-time:
+        specifier: ^1.5.0
+        version: 1.5.0
       sanitize-html:
         specifier: ^2.17.0
         version: 2.17.0
@@ -2674,6 +2677,9 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  reading-time@1.5.0:
+    resolution: {integrity: sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==}
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -6579,6 +6585,8 @@ snapshots:
   radix3@1.1.2: {}
 
   readdirp@4.1.2: {}
+
+  reading-time@1.5.0: {}
 
   recma-build-jsx@1.0.0:
     dependencies:

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from "./Layout.astro";
-const { frontmatter } = Astro.props;
+const { frontmatter, readingTimeMinutes } = Astro.props;
 /** TODO: different formats for different kinds of pages
 - one-off pages should have: flex flex-col items-center justify-center
 - long form pages (like my current work page, random notes dumps, etc, should have less margins and left justification
@@ -12,7 +12,16 @@ const { frontmatter } = Astro.props;
   class="min-w-screen min-h-screen flex justify-center my-12 md:my-16 prose md:prose-lg ld:prose-xl prose-stone prose-headings:font-literata prose-headings:font-bold"
 >
   <div class="mx-8 md:w-1/2 leading-6 pb-8">
-    {frontmatter?.title && <h1>{frontmatter.title}</h1>}
+    {
+      frontmatter?.title && (
+        <header class="title-block">
+          <h1>{frontmatter.title}</h1>
+          {readingTimeMinutes && (
+            <p class="reading-time">{readingTimeMinutes} min read</p>
+          )}
+        </header>
+      )
+    }
     <slot />
     {
       frontmatter?.tags && frontmatter.tags.length > 0 && (
@@ -29,6 +38,25 @@ const { frontmatter } = Astro.props;
 </Layout>
 
 <style>
+  .title-block {
+    margin-bottom: 2rem;
+  }
+
+  .title-block :global(h1) {
+    margin-bottom: 0.25rem;
+  }
+
+  .reading-time {
+    display: block;
+    font-size: 0.85rem;
+    font-style: italic;
+    font-variant: small-caps;
+    letter-spacing: 0.03em;
+    color: var(--tw-prose-captions, rgba(0, 0, 0, 0.55));
+    opacity: 0.7;
+    margin: 0;
+  }
+
   .tags {
     margin-top: 2rem;
     display: flex;

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -27,13 +27,16 @@ const publishedOnIso = showPublishedOn ? publishedOn.toISOString() : undefined;
       frontmatter?.title && (
         <header class="title-block">
           <h1>{frontmatter.title}</h1>
-          {publishedOnFormatted && (
-            <time class="published-on" datetime={publishedOnIso}>
-              {publishedOnFormatted}
-            </time>
-          )}
-          {readingTimeMinutes && (
-            <p class="reading-time">{readingTimeMinutes} min read</p>
+          {(publishedOnFormatted || readingTimeMinutes) && (
+            <p class="post-meta">
+              {publishedOnFormatted && (
+                <time datetime={publishedOnIso}>{publishedOnFormatted}</time>
+              )}
+              {publishedOnFormatted && readingTimeMinutes && (
+                <span aria-hidden="true"> · </span>
+              )}
+              {readingTimeMinutes && <span>{readingTimeMinutes} min read</span>}
+            </p>
           )}
         </header>
       )
@@ -55,22 +58,18 @@ const publishedOnIso = showPublishedOn ? publishedOn.toISOString() : undefined;
 
 <style>
   .title-block {
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
   }
 
   .title-block :global(h1) {
     margin-bottom: 0.25rem;
   }
 
-  .published-on,
-  .reading-time {
-    display: block;
+  .post-meta {
     font-size: 0.85rem;
-    font-style: italic;
     font-variant: small-caps;
     letter-spacing: 0.03em;
-    color: var(--tw-prose-captions, rgba(0, 0, 0, 0.55));
-    opacity: 0.7;
+    color: var(--tw-prose-body, rgba(0, 0, 0, 0.75));
     margin: 0;
   }
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -3,6 +3,7 @@ import { render } from "astro:content";
 import ProseLayout from "../../layouts/ProseLayout.astro";
 import AudioPlayer from "../../components/AudioPlayer.astro";
 import { getPublishedEntries } from "../../utils/collections";
+import { getReadingTimeMinutes } from "../../utils/reading-time";
 
 export async function getStaticPaths() {
   const blogPosts = await getPublishedEntries("blog");
@@ -14,9 +15,10 @@ export async function getStaticPaths() {
 
 const { blogPost } = Astro.props;
 const { Content } = await render(blogPost);
+const readingTimeMinutes = getReadingTimeMinutes(blogPost.body);
 ---
 
-<ProseLayout frontmatter={blogPost.data}>
+<ProseLayout frontmatter={blogPost.data} readingTimeMinutes={readingTimeMinutes}>
   <Content />
   {
     blogPost.data.audio && (

--- a/src/pages/weeknotes/[...slug].astro
+++ b/src/pages/weeknotes/[...slug].astro
@@ -2,6 +2,7 @@
 import { render } from "astro:content";
 import ProseLayout from "../../layouts/ProseLayout.astro";
 import { getPublishedEntries } from "../../utils/collections";
+import { getReadingTimeMinutes } from "../../utils/reading-time";
 
 export async function getStaticPaths() {
   const weeknotes = await getPublishedEntries("weeknotes");
@@ -13,8 +14,9 @@ export async function getStaticPaths() {
 
 const { weeknote } = Astro.props;
 const { Content } = await render(weeknote);
+const readingTimeMinutes = getReadingTimeMinutes(weeknote.body);
 ---
 
-<ProseLayout frontmatter={weeknote.data}>
+<ProseLayout frontmatter={weeknote.data} readingTimeMinutes={readingTimeMinutes}>
   <Content />
 </ProseLayout>

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -1,0 +1,9 @@
+import readingTime from "reading-time";
+
+const MINIMUM_MINUTES = 5;
+
+export function getReadingTimeMinutes(body: string | undefined): number | null {
+  if (!body) return null;
+  const minutes = Math.ceil(readingTime(body).minutes);
+  return minutes > MINIMUM_MINUTES ? minutes : null;
+}


### PR DESCRIPTION
Shows a "N min read" label below the title on blog and weeknote
posts where reading time exceeds 5 minutes. Uses the reading-time
package for word counting and styles the indicator to match the
published-on metadata styling so the two read cohesively when both
are present.

https://claude.ai/code/session_01NVrvb8chSJktALVM3t6V83