### PR TITLE
Add dynamic page titles with category suffixes

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,6 @@
 ---
 import "/src/styles/global.css";
-const { class: className } = Astro.props;
+const { class: className, title } = Astro.props;
 ---
 
 <html lang="en">
@@ -51,7 +51,7 @@ const { class: className } = Astro.props;
       type="image/svg+xml"
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22256%22 height=%22256%22 viewBox=%220 0 100 100%22><text x=%2250%%22 y=%2250%%22 dominant-baseline=%22central%22 text-anchor=%22middle%22 font-size=%22110%22>🪭</text></svg>"
     />
-    <title>Tanvi's Web Home</title>
+    <title>{`${title ? `${title} | ` : ""}Tanvi's Web Home`}</title>
     <script
       defer
       data-domain="tanvibhakta.in"

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -1,6 +1,22 @@
 ---
 import Layout from "./Layout.astro";
-const { frontmatter, readingTimeMinutes, hidePublishedOn } = Astro.props;
+import { shortenWeeknoteTitles } from "../utils/date-helpers";
+
+const { frontmatter, category, readingTimeMinutes, hidePublishedOn } =
+  Astro.props;
+
+let pageTitle = "";
+if (frontmatter?.title) {
+  if (category === "weeknotes") {
+    pageTitle = `${shortenWeeknoteTitles(frontmatter.title)} | Weeknote`;
+  } else if (category === "blog") {
+    pageTitle = `${frontmatter.title} | Blog`;
+  } else if (category === "poetry") {
+    pageTitle = `${frontmatter.title} | Poetry`;
+  } else {
+    pageTitle = frontmatter.title;
+  }
+}
 /** TODO: different formats for different kinds of pages
 - one-off pages should have: flex flex-col items-center justify-center
 - long form pages (like my current work page, random notes dumps, etc, should have less margins and left justification
@@ -20,6 +36,7 @@ const publishedOnIso = showPublishedOn ? publishedOn.toISOString() : undefined;
 ---
 
 <Layout
+  title={pageTitle}
   class="min-w-screen min-h-screen flex justify-center my-12 md:my-16 prose md:prose-lg ld:prose-xl prose-stone prose-headings:font-literata prose-headings:font-bold"
 >
   <div class="mx-8 md:w-1/2 leading-6 pb-8">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -18,7 +18,11 @@ const { Content } = await render(blogPost);
 const readingTimeMinutes = getReadingTimeMinutes(blogPost.body);
 ---
 
-<ProseLayout frontmatter={blogPost.data} readingTimeMinutes={readingTimeMinutes}>
+<ProseLayout
+  frontmatter={blogPost.data}
+  category="blog"
+  readingTimeMinutes={readingTimeMinutes}
+>
   <Content />
   {
     blogPost.data.audio && (

--- a/src/pages/digital-garden/index.astro
+++ b/src/pages/digital-garden/index.astro
@@ -39,7 +39,7 @@ const postsWithDescriptions = await Promise.all(
 );
 ---
 
-<ProseLayout>
+<ProseLayout frontmatter={{ title: "Digital Garden" }}>
   <h1>Digital Garden</h1>
 
   {

--- a/src/pages/poetry/[...slug].astro
+++ b/src/pages/poetry/[...slug].astro
@@ -16,7 +16,7 @@ const { poem } = Astro.props;
 const { Content } = await render(poem);
 ---
 
-<ProseLayout frontmatter={poem.data}>
+<ProseLayout frontmatter={poem.data} category="poetry">
   <Content />
   {
     poem.data.audio && (

--- a/src/pages/weeknotes/[...slug].astro
+++ b/src/pages/weeknotes/[...slug].astro
@@ -19,6 +19,7 @@ const readingTimeMinutes = getReadingTimeMinutes(weeknote.body);
 
 <ProseLayout
   frontmatter={weeknote.data}
+  category="weeknotes"
   readingTimeMinutes={readingTimeMinutes}
   hidePublishedOn
 >

--- a/src/pages/weeknotes/index.astro
+++ b/src/pages/weeknotes/index.astro
@@ -13,7 +13,7 @@ const { Content } = latestWeeknote
   : { Content: null };
 ---
 
-<ProseLayout>
+<ProseLayout frontmatter={{ title: "Weeknotes" }}>
   {
     latestWeeknote && (
       <article>

--- a/src/utils/date-helpers.ts
+++ b/src/utils/date-helpers.ts
@@ -1,0 +1,18 @@
+export function getOrdinalSuffix(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return s[(v - 20) % 10] || s[v] || s[0];
+}
+
+export function shortenWeeknoteTitles(title: string): string {
+  const match = title.match(/Week of (\w+) (\d+)(?:st|nd|rd|th)?,? (\d+)/);
+  if (!match) return title;
+
+  const [, monthName, day, year] = match;
+  const date = new Date(`${monthName} ${day}, ${year}`);
+  if (isNaN(date.getTime())) return title;
+
+  const shortMonth = date.toLocaleDateString("en-US", { month: "short" });
+  const suffix = getOrdinalSuffix(parseInt(day));
+  return `${shortMonth} ${day}${suffix}`;
+}

--- a/tests/date-helpers.test.ts
+++ b/tests/date-helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "vitest";
+import { shortenWeeknoteTitles } from "../src/utils/date-helpers";
+
+describe("shortenWeeknoteTitles", () => {
+  test("shortens full month name with ordinal suffix", () => {
+    expect(shortenWeeknoteTitles("Week of September 7th, 2025")).toBe(
+      "Sep 7th",
+    );
+    expect(shortenWeeknoteTitles("Week of December 25th, 2024")).toBe(
+      "Dec 25th",
+    );
+    expect(shortenWeeknoteTitles("Week of April 30th, 2025")).toBe("Apr 30th");
+  });
+
+  test("shortens abbreviated month with ordinal suffix", () => {
+    expect(shortenWeeknoteTitles("Week of Apr 11th, 2026")).toBe("Apr 11th");
+    expect(shortenWeeknoteTitles("Week of Aug 23rd, 2025")).toBe("Aug 23rd");
+    expect(shortenWeeknoteTitles("Week of Jan 1st, 2025")).toBe("Jan 1st");
+  });
+
+  test("adds ordinal suffix when missing from title", () => {
+    expect(shortenWeeknoteTitles("Week of Apr 2, 2025")).toBe("Apr 2nd");
+    expect(shortenWeeknoteTitles("Week of Mar 26, 2025")).toBe("Mar 26th");
+  });
+
+  test("returns original title for unrecognized formats", () => {
+    expect(shortenWeeknoteTitles("Month of November, 2025")).toBe(
+      "Month of November, 2025",
+    );
+    expect(shortenWeeknoteTitles("Week of 16 Apr, 2025")).toBe(
+      "Week of 16 Apr, 2025",
+    );
+    expect(shortenWeeknoteTitles("Week of 5th April, 2026")).toBe(
+      "Week of 5th April, 2026",
+    );
+  });
+});

--- a/tests/page-titles.test.ts
+++ b/tests/page-titles.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect, beforeAll } from "vitest";
+import * as cheerio from "cheerio";
+import { fileURLToPath } from "url";
+import path from "path";
+import fs from "fs";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+function extractTitle(html: string): string {
+  const $ = cheerio.load(html);
+  return $("title").text();
+}
+
+describe("Page Titles", () => {
+  let distDir: string;
+
+  beforeAll(async () => {
+    await execAsync("pnpm run build");
+    distDir = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../dist",
+    );
+  }, 120000);
+
+  test("Homepage has no title prefix", async () => {
+    const html = await fs.promises.readFile(
+      path.join(distDir, "index.html"),
+      "utf8",
+    );
+    expect(extractTitle(html)).toBe("Tanvi's Web Home");
+  });
+
+  test("Blog index has correct title", async () => {
+    const html = await fs.promises.readFile(
+      path.join(distDir, "blog/index.html"),
+      "utf8",
+    );
+    expect(extractTitle(html)).toBe("Blog | Tanvi's Web Home");
+  });
+
+  test("Poetry index has correct title", async () => {
+    const html = await fs.promises.readFile(
+      path.join(distDir, "poetry/index.html"),
+      "utf8",
+    );
+    expect(extractTitle(html)).toBe("Poetry | Tanvi's Web Home");
+  });
+
+  test("Weeknotes index has correct title", async () => {
+    const html = await fs.promises.readFile(
+      path.join(distDir, "weeknotes/index.html"),
+      "utf8",
+    );
+    expect(extractTitle(html)).toBe("Weeknotes | Tanvi's Web Home");
+  });
+
+  test("Digital Garden index has correct title", async () => {
+    const html = await fs.promises.readFile(
+      path.join(distDir, "digital-garden/index.html"),
+      "utf8",
+    );
+    expect(extractTitle(html)).toBe("Digital Garden | Tanvi's Web Home");
+  });
+
+  test("Blog post has title with Blog suffix", async () => {
+    const blogDir = path.join(distDir, "blog");
+    const entries = await fs.promises.readdir(blogDir);
+    const posts = entries.filter(
+      (e) =>
+        e !== "feed.xml" && fs.statSync(path.join(blogDir, e)).isDirectory(),
+    );
+
+    const html = await fs.promises.readFile(
+      path.join(blogDir, posts[0], "index.html"),
+      "utf8",
+    );
+    expect(extractTitle(html)).toMatch(/^.+ \| Blog \| Tanvi's Web Home$/);
+  });
+
+  test("Weeknote has shortened title with Weeknote suffix", async () => {
+    const weeknotesDir = path.join(distDir, "weeknotes");
+    const entries = await fs.promises.readdir(weeknotesDir);
+    const posts = entries.filter(
+      (e) =>
+        e !== "feed.xml" &&
+        fs.statSync(path.join(weeknotesDir, e)).isDirectory(),
+    );
+
+    const html = await fs.promises.readFile(
+      path.join(weeknotesDir, posts[0], "index.html"),
+      "utf8",
+    );
+    expect(extractTitle(html)).toMatch(/^.+ \| Weeknote \| Tanvi's Web Home$/);
+  });
+
+  test("Poetry post has title with Poetry suffix", async () => {
+    const poetryDir = path.join(distDir, "poetry");
+    const entries = await fs.promises.readdir(poetryDir);
+    const posts = entries.filter(
+      (e) =>
+        e !== "feed.xml" && fs.statSync(path.join(poetryDir, e)).isDirectory(),
+    );
+
+    const html = await fs.promises.readFile(
+      path.join(poetryDir, posts[0], "index.html"),
+      "utf8",
+    );
+    expect(extractTitle(html)).toMatch(/^.+ \| Poetry \| Tanvi's Web Home$/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     exclude: [".claude/worktrees/**", ".worktrees/**", "node_modules/**"],
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary

- `Layout.astro` now accepts a `title` prop and renders `title | Tanvi's Web Home` when provided
- `ProseLayout.astro` derives formatted title from `frontmatter.title` + explicit `category` prop (no URL-path parsing)
- Weeknote titles shortened: `"Week of September 7th, 2025"` → `"Sep 7th | Weeknote | Tanvi's Web Home"`
- Route pages (`blog`, `weeknotes`, `poetry` slugs) pass `category` to `ProseLayout`
- Index pages missing `frontmatter` (`weeknotes`, `digital-garden`) now pass `frontmatter={{ title: "..." }}`
- Adds `src/utils/date-helpers.ts` with `shortenWeeknoteTitles` + `getOrdinalSuffix`
- Adds unit tests (`date-helpers.test.ts`) and integration tests (`page-titles.test.ts`)
- Adds `fileParallelism: false` to vitest config to prevent concurrent build conflicts

Reimplementation of `feat/create-dynamic-page-titles` — old branch was 100+ commits behind main and had a broken test (`npm run build` instead of `pnpm`).

## Test Plan

- [x] 28/28 tests passing locally
- [x] Pre-commit hook passes (lint-staged + full vitest suite)
- [ ] CI green
- [ ] Spot-check pages in browser: blog post, weeknote, poetry, index pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)