### PR TITLE
feat: add persistent nav bar to non-home pages

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,0 +1,72 @@
+---
+type Section = { label: string; href: string };
+
+const NAV_ITEMS: readonly Section[] = [
+  { label: "Work", href: "/work" },
+  { label: "Blog", href: "/blog" },
+  { label: "Weeknotes", href: "/weeknotes" },
+] as const;
+
+const KNOWN_SECTIONS: readonly Section[] = [
+  ...NAV_ITEMS,
+  { label: "Poetry", href: "/poetry" },
+  { label: "Digital Garden", href: "/digital-garden" },
+  { label: "Tags", href: "/tags" },
+  { label: "Subscribe", href: "/subscribe" },
+] as const;
+
+function titleCase(slug: string): string {
+  return slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function getCurrentSection(path: string): Section | undefined {
+  const known = [...KNOWN_SECTIONS]
+    .sort((a, b) => b.href.length - a.href.length)
+    .find((s) => path === s.href || path.startsWith(`${s.href}/`));
+  if (known) return known;
+
+  const firstSegment = path.split("/").filter(Boolean)[0];
+  if (!firstSegment || firstSegment === "404") return undefined;
+  return { label: titleCase(firstSegment), href: `/${firstSegment}` };
+}
+
+const current = getCurrentSection(Astro.url.pathname);
+const inMainNav =
+  current && NAV_ITEMS.some((item) => item.href === current.href);
+const items: Section[] =
+  !current || inMainNav ? [...NAV_ITEMS] : [current, ...NAV_ITEMS];
+---
+
+<header
+  class="not-prose w-full max-w-5xl mx-auto px-6 md:px-10 my-6 flex items-center justify-between gap-6"
+>
+  <a href="/" class="text-neutral-800! font-literata text-2xl sm:text-3xl">
+    Tanvi Bhakta
+  </a>
+
+  <nav aria-label="Primary">
+    <ul
+      class="flex flex-wrap items-center justify-end list-none p-0 m-0 gap-4 sm:gap-6 sm:text-lg"
+    >
+      {
+        items.map((item) => (
+          <li>
+            <a
+              href={item.href}
+              aria-current={current?.href === item.href ? "page" : undefined}
+              class:list={[
+                current?.href === item.href &&
+                  "underline underline-offset-2 decoration-2",
+              ]}
+            >
+              {item.label}
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </nav>
+</header>

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "./Layout.astro";
+import Nav from "../components/Nav.astro";
 import { shortenWeeknoteTitles } from "../utils/date-helpers";
 
 const { frontmatter, category, readingTimeMinutes, hidePublishedOn } =
@@ -37,9 +38,12 @@ const publishedOnIso = showPublishedOn ? publishedOn.toISOString() : undefined;
 
 <Layout
   title={pageTitle}
-  class="min-w-screen min-h-screen flex justify-center my-12 md:my-16 prose md:prose-lg ld:prose-xl prose-stone prose-headings:font-literata prose-headings:font-bold"
+  class="min-w-screen min-h-screen flex flex-col items-center text-stone-800 bg-stone-100"
 >
-  <div class="mx-8 md:w-1/2 leading-6 pb-8">
+  <Nav />
+  <article
+    class="mx-8 md:w-1/2 leading-6 pb-8 mt-6 md:mt-8 prose md:prose-lg ld:prose-xl prose-stone prose-headings:font-literata prose-headings:font-bold"
+  >
     {
       frontmatter?.title && (
         <header class="title-block">
@@ -70,7 +74,7 @@ const publishedOnIso = showPublishedOn ? publishedOn.toISOString() : undefined;
         </div>
       )
     }
-  </div>
+  </article>
 </Layout>
 
 <style>


### PR DESCRIPTION
## Summary
- New `Nav.astro` component renders a single-line nav bar on every non-home page (drawn from the home page's title-page styling).
- Highlights the current section with a thicker (2px) underline at offset 2.
- For pages outside the main nav (Poetry, Digital Garden, Tags, Subscribe, plus one-off pages like `/now`, `/care`), prepends the section as the first item linking to its index.
- Wired into `ProseLayout.astro`; home page (`Header.astro`) is untouched.

## Test plan
- [x] `pnpm build` succeeds (118 pages)
- [x] `pnpm test` green (37/37, including link checker)
- [ ] Visit `/blog`, `/blog/<post>` — Blog underlined, Work/Blog/Weeknotes only
- [ ] Visit `/poetry`, `/poetry/<poem>` — Poetry prepended and underlined
- [ ] Visit `/digital-garden`, `/tags`, `/subscribe` — section prepended and underlined
- [ ] Visit `/now`, `/care` — section title derived from URL, prepended and underlined
- [ ] Visit `/` — original hero header unchanged
- [ ] Mobile + mobile-landscape — nav wraps cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)