### PR TITLE
feat: render full poems on /poetry, with per-entry anchor opt-out

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,7 +29,7 @@ export default defineConfig({
         content: { type: 'text', value: ' #' },
         test: (node) => node.tagName !== 'h1',
       }],
-      rehypeAnchors,
+      [rehypeAnchors, { skip: (file) => /[\\/]posts[\\/]poetry[\\/]/.test(file?.path ?? "") }],
     ],
   },
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,12 +4,16 @@ import { glob } from "astro/loaders";
 export const TAGS = ["ai-usage", "konkani", "philosophy", "reviews"] as const;
 export type Tag = (typeof TAGS)[number];
 
-// Common schema for all collections
+// Common schema for all collections.
+// `anchors` toggles the rehype-anchors plugin per entry — set false to skip
+// generating per-paragraph / per-list-item `#` links. Collection-wide
+// defaults are configured via the plugin's `skip` option in astro.config.
 const collectionSchema = z.object({
   title: z.string(),
   publishedOn: z.date(),
   draft: z.boolean().optional(),
   tags: z.array(z.enum(TAGS)).optional().default([]),
+  anchors: z.boolean().optional(),
 });
 
 // Manually define collections for now

--- a/src/pages/poetry/index.astro
+++ b/src/pages/poetry/index.astro
@@ -1,18 +1,34 @@
 ---
+import { render } from "astro:content";
 import ProseLayout from "../../layouts/ProseLayout.astro";
+import AudioPlayer from "../../components/AudioPlayer.astro";
 import { getPublishedEntries } from "../../utils/collections";
+
 const allPoetry = await getPublishedEntries("poetry");
 
 const sorted = allPoetry.sort(
   (a, b) => a.data.publishedOn.getTime() - b.data.publishedOn.getTime(),
 );
 
-const poetry2025 = sorted.filter(
-  (poem) => poem.data.publishedOn.getFullYear() === 2025,
+const renderedPoetry = await Promise.all(
+  sorted.map(async (poem) => ({
+    poem,
+    Content: (await render(poem)).Content,
+  })),
 );
-const poetry2026 = sorted.filter(
-  (poem) => poem.data.publishedOn.getFullYear() === 2026,
+
+const poetry2025 = renderedPoetry.filter(
+  ({ poem }) => poem.data.publishedOn.getFullYear() === 2025,
 );
+const poetry2026 = renderedPoetry.filter(
+  ({ poem }) => poem.data.publishedOn.getFullYear() === 2026,
+);
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
 
 const frontmatter = {
   title: "Poetry",
@@ -22,32 +38,78 @@ const frontmatter = {
 <ProseLayout frontmatter={frontmatter}>
   <h2>Global Poetry Writing Month 2026</h2>
   {
-    (
-      <ul>
-        {poetry2026.map((poem) => (
-          <li>
+    poetry2026.map(({ poem, Content }) => (
+      <article class="my-10">
+        <header class="not-prose mb-4">
+          <h3 class="font-literata text-xl font-bold">
             <a href={`/poetry/${poem.id}`}>{poem.data.title}</a>
-          </li>
-        ))}
-      </ul>
-    )
+          </h3>
+          <p class="mt-1 text-sm tracking-wide opacity-75 [font-variant:small-caps]">
+            <time datetime={poem.data.publishedOn.toISOString()}>
+              {dateFormatter.format(poem.data.publishedOn)}
+            </time>
+          </p>
+        </header>
+        <Content />
+        {poem.data.audio && (
+          <AudioPlayer
+            src={poem.data.audio}
+            title={poem.data.audioTitle ?? "Listen to this poem"}
+          />
+        )}
+        {poem.data.tags && poem.data.tags.length > 0 && (
+          <div class="mt-4 flex flex-wrap gap-2">
+            {poem.data.tags.map((tag) => (
+              <a
+                href={`/tags/${tag}`}
+                class="text-xs text-inherit no-underline opacity-60 [font-variant:small-caps] hover:underline hover:opacity-100"
+              >
+                {tag}
+              </a>
+            ))}
+          </div>
+        )}
+      </article>
+    ))
   }
 
   <h2>Global Poetry Writing Month 2025</h2>
-  <a href={`/blog/global-poetry-writing-month-2025`}>Introductory post</a>
-  <ul>
-    {
-      poetry2025.map((poem) => (
-        <li>
-          <a href={`/poetry/${poem.id}`}>{poem.data.title}</a>
-        </li>
-      ))
-    }
-  </ul>
-</ProseLayout>
-
-<style>
-  ul {
-    list-style: none;
+  <p>
+    <a href="/blog/global-poetry-writing-month-2025">Introductory post</a>
+  </p>
+  {
+    poetry2025.map(({ poem, Content }) => (
+      <article class="my-10">
+        <header class="not-prose mb-4">
+          <h3 class="font-literata text-xl font-bold">
+            <a href={`/poetry/${poem.id}`}>{poem.data.title}</a>
+          </h3>
+          <p class="mt-1 text-sm tracking-wide opacity-75 [font-variant:small-caps]">
+            <time datetime={poem.data.publishedOn.toISOString()}>
+              {dateFormatter.format(poem.data.publishedOn)}
+            </time>
+          </p>
+        </header>
+        <Content />
+        {poem.data.audio && (
+          <AudioPlayer
+            src={poem.data.audio}
+            title={poem.data.audioTitle ?? "Listen to this poem"}
+          />
+        )}
+        {poem.data.tags && poem.data.tags.length > 0 && (
+          <div class="mt-4 flex flex-wrap gap-2">
+            {poem.data.tags.map((tag) => (
+              <a
+                href={`/tags/${tag}`}
+                class="text-xs text-inherit no-underline opacity-60 [font-variant:small-caps] hover:underline hover:opacity-100"
+              >
+                {tag}
+              </a>
+            ))}
+          </div>
+        )}
+      </article>
+    ))
   }
-</style>
+</ProseLayout>

--- a/src/plugins/rehype-anchors.mjs
+++ b/src/plugins/rehype-anchors.mjs
@@ -1,7 +1,28 @@
 import { visit } from "unist-util-visit";
 
-export function rehypeAnchors() {
-  return (tree) => {
+/**
+ * Adds `#`-style permalink anchors to every paragraph and list item.
+ *
+ * Disabling:
+ *   - Per-entry: set `anchors: false` in the markdown file's frontmatter.
+ *   - Collection-wide / path-based: pass a `skip` predicate when registering
+ *     the plugin in `astro.config.mjs`, e.g.
+ *
+ *       [rehypeAnchors, { skip: (file) => file.path?.includes("/poetry/") }]
+ *
+ * Frontmatter `anchors: false` always wins; `skip` is a default applied per
+ * file path. The plugin runs once per file at content-sync time.
+ */
+export function rehypeAnchors(options = {}) {
+  const { skip } = options;
+
+  return (tree, file) => {
+    const fm = file?.data?.astro?.frontmatter;
+    if (fm?.anchors === false) return;
+    if (fm?.anchors !== true && typeof skip === "function" && skip(file)) {
+      return;
+    }
+
     let pCount = 0;
     let liCount = 0;
 

--- a/tests/rehype-anchors.test.ts
+++ b/tests/rehype-anchors.test.ts
@@ -22,9 +22,15 @@ function text(value: string): HastText {
   return { type: "text", value };
 }
 
-function run(tree: { type: "root"; children: HastNode[] }) {
+function run(
+  tree: { type: "root"; children: HastNode[] },
+  pluginArgs: {
+    options?: Parameters<typeof rehypeAnchors>[0];
+    file?: object;
+  } = {},
+) {
   // @ts-expect-error - hast tree shape
-  rehypeAnchors()(tree);
+  rehypeAnchors(pluginArgs.options)(tree, pluginArgs.file);
   return tree;
 }
 
@@ -145,6 +151,54 @@ describe("rehypeAnchors (paragraphs + list items)", () => {
     // blockquote untouched, but inner <p> still gets anchored
     const innerP = (tree.children[1] as HastElement).children[0] as HastElement;
     expect(lastChild(innerP).properties.href).toBe("#p-1");
+  });
+
+  test("frontmatter anchors:false skips the entire entry", () => {
+    const tree = {
+      type: "root" as const,
+      children: [elem("p", {}, [text("hi")])],
+    };
+    run(tree, {
+      file: { data: { astro: { frontmatter: { anchors: false } } } },
+    });
+
+    const p = tree.children[0] as HastElement;
+    expect(p.properties.id).toBeUndefined();
+    expect(p.children).toHaveLength(1);
+  });
+
+  test("config-level skip predicate skips matching files", () => {
+    const tree = {
+      type: "root" as const,
+      children: [elem("p", {}, [text("hi")])],
+    };
+    run(tree, {
+      options: { skip: (file) => file?.path?.includes("/poetry/") },
+      file: {
+        path: "/posts/poetry/day-1.md",
+        data: { astro: { frontmatter: {} } },
+      },
+    });
+
+    const p = tree.children[0] as HastElement;
+    expect(p.properties.id).toBeUndefined();
+  });
+
+  test("frontmatter anchors:true overrides a config-level skip", () => {
+    const tree = {
+      type: "root" as const,
+      children: [elem("p", {}, [text("hi")])],
+    };
+    run(tree, {
+      options: { skip: () => true },
+      file: {
+        path: "/posts/poetry/day-1.md",
+        data: { astro: { frontmatter: { anchors: true } } },
+      },
+    });
+
+    const p = tree.children[0] as HastElement;
+    expect(p.properties.id).toBe("p-1");
   });
 
   test("anchor link uses anchor-link class with appropriate aria-label", () => {


### PR DESCRIPTION
## Summary
- The `/poetry` index now renders every poem's full body inline (titles still link through to individual poem pages, dates rendered with each entry; tags/audio render when present).
- Redesigns `rehypeAnchors` so anchor generation can be disabled cleanly:
  - **Config-level** `skip` predicate (used here to turn anchors off for the entire poetry collection in one line of `astro.config.mjs`)
  - **Per-entry** `anchors: false` frontmatter override (always wins over the config skip)
- Avoids previous workarounds (parallel markdown-it pipeline, cheerio post-process) that were considered too hacky.

## Test plan
- [x] `pnpm test` — all 40 tests pass (3 new tests cover the disable paths)
- [x] `pnpm build` — site builds clean; `dist/poetry/index.html` has 0 paragraph anchor IDs; sample blog post still has its anchors
- [ ] Visual check on Netlify preview: poetry index shows all poems with full body, audio + tags where applicable, no `#` anchor links visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)