### PR TITLE
Hidden draft permalinks under /drafts/

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,17 +3,17 @@ import { defineConfig } from "astro/config";
 
 import tailwindcss from "@tailwindcss/vite";
 
-import mdx from '@astrojs/mdx';
-import sitemap from '@astrojs/sitemap';
-import icon from 'astro-icon';
-import remarkBreaks from 'remark-breaks';
-import rehypeSlug from 'rehype-slug';
-import rehypeAutolinkHeadings from 'rehype-autolink-headings';
-import { rehypeAnchors } from './src/plugins/rehype-anchors.mjs';
+import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
+import icon from "astro-icon";
+import remarkBreaks from "remark-breaks";
+import rehypeSlug from "rehype-slug";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import { rehypeAnchors } from "./src/plugins/rehype-anchors.mjs";
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://tanvibhakta.in',
+  site: "https://tanvibhakta.in",
 
   vite: {
     plugins: [tailwindcss()],
@@ -23,16 +23,22 @@ export default defineConfig({
     remarkPlugins: [remarkBreaks],
     rehypePlugins: [
       rehypeSlug,
-      [rehypeAutolinkHeadings, {
-        behavior: 'append',
-        properties: {
-          className: ['anchor-link'],
-          ariaLabel: 'Link to this section',
+      [
+        rehypeAutolinkHeadings,
+        {
+          behavior: "append",
+          properties: {
+            className: ["anchor-link"],
+            ariaLabel: "Link to this section",
+          },
+          content: { type: "text", value: " #" },
+          test: (node) => node.tagName !== "h1",
         },
-        content: { type: 'text', value: ' #' },
-        test: (node) => node.tagName !== 'h1',
-      }],
-      [rehypeAnchors, { skip: (file) => /[\\/]posts[\\/]poetry[\\/]/.test(file?.path ?? "") }],
+      ],
+      [
+        rehypeAnchors,
+        { skip: (file) => /[\\/]posts[\\/]poetry[\\/]/.test(file?.path ?? "") },
+      ],
     ],
   },
 
@@ -41,26 +47,28 @@ export default defineConfig({
     //   status: 302,
     //   destination: 'https://tanvibhakta.mataroa.blog'
     // },
-    '/resume': {
+    "/resume": {
       status: 301,
-      destination: '/resume.pdf'
+      destination: "/resume.pdf",
     },
-    '/code': {
+    "/code": {
       status: 301,
-      destination: 'https://github.com/tanvibhakta'
-    }
+      destination: "https://github.com/tanvibhakta",
+    },
   },
 
   integrations: [
     mdx(),
     icon(),
     sitemap({
-      // Keep admin tooling, machine-readable feeds, and underscore-prefixed
-      // fixture pages (e.g. /_anchor-fixture) out of the sitemap.
+      // Keep admin tooling, machine-readable feeds, draft review pages, and
+      // underscore-prefixed fixture pages (e.g. /_anchor-fixture) out of the
+      // sitemap.
       filter: (page) =>
-        !page.includes('/admin') &&
-        !page.endsWith('/feed.xml') &&
+        !page.includes("/admin") &&
+        !page.endsWith("/feed.xml") &&
+        !new URL(page).pathname.startsWith("/drafts/") &&
         !/\/_/.test(new URL(page).pathname),
     }),
-  ]
+  ],
 });

--- a/posts/blog/repetition.md
+++ b/posts/blog/repetition.md
@@ -1,0 +1,25 @@
+---
+title: "Repetition"
+publishedOn: 2026-07-18
+draft: true
+---
+
+There is a certain magic to repetition.
+
+Long ago, in response to a story where someone was forced to change their password every three months, I read the advice to make that password something that they wanted to focus on. Yes, we have touch ID, but I still type in my password 7 to 12 times a day. So this advice made sense to me. It comes from the same genre as, on the low-effort, low-effect part of the scale, “write out what you want and put it above your bed so it's the first thing you see when you wake up”, and high-effort, high-effectiveness being “Re-design your whole office so that walking through the corridors prepares your mind for the thing you need to spend the next 8 hours focusing on”[^1]
+
+What you pay attention to, grows.
+
+Your subconscious mind is paying attention to the things your hands are doing, even if you don't really notice. Four years ago, I changed the login password on all my laptops to `publish`. Just the one word. I had been frustrated with wanting to write, but that frustration wasn’t helping me write. Or I was writing, but then I was letting it die in my drafts. I wanted to write and see it through!
+
+For the next year and a half, every few hours as I would type the word publish (whether I actively paid attention or not) my subconscious brain oriented towards finishing what I had started writing. It paid attention to the barriers stopping me from putting my work out there, and then worked on dismantling them. I didn’t have a blog on the website, so I [wrote on mataroa](https://tanvibhakta.mataroa.blog/). I felt like I had nothing to say (about anything important), so I wrote [weeknotes](/weeknotes) (and discovered I was wrong). I attended a [writing workshop for nerds](https://www.evalapply.org/#writing-for-nerds). I started Writer’s Club. I started [Indie Web Club](https://blr.indiewebclub.org/). Here we are.
+
+My next password was to `do the boring thing`[^2]. It’s no surprise that people don’t do hard things - but we must try, every so often, because only through discomfort can we grow. For me, it was hard to be bored. It was hard to pay attention to any one thing for more than half an hour. I would constantly get distracted, with the flavor of “let me check my messages”, but also, “here is a thought. Why don't I look it up immediately and fall down this rabbit hole where I'm clicking a new link every 90 seconds instead of sitting with this hard problem that I haven't yet taught my brain how to understand?” And so I decided to remind myself, every login, every `sudo` password, every time I have to unlock my keychain access, to Do The Boring Thing instead.
+
+In the time since this change, I am one year through working the hardest job I have ever worked, the longest hours I have ever worked, learning the most I have ever learnt in my career. I now have conclusive proof that I’m not lazy (take that, depression brain!). I _can_ do boring things. Along the way, I also learned to do the hard things. I don't have to turn the boring things interesting. I can just accept that they need to be done, and sit down and make it happen.
+
+It's time for a new laptop password. While I figure it out, I'm trying to remind myself - there is a certain magic to repetition.
+
+[^1]: Cal Newport: Deep Work. See also: obvious.in office redesign principles (link currently lost to the void)
+
+[^2]: At the end of May 2025, a few friends caught up with [Pooja Saxena](https://anexasajoop.in/) who was in town for coffee. We were shooting the shit and the conversation turned to how the work just needs to be done. Pooja talked about how her and [Prateek](https://prtksxna.com/) kept each other work accountable via gentle ribbing, and also how when [her dad](https://github.com/sanjayaksaxena) (who is now in his sixties!) complains that the work he has to do to get a [passion project](https://github.com/winkjs/wink-nlp) done is hard, she doesn’t have patience for it because he just has to sit down and do it - and she tells him so. This conversation left a deep impression on me. She is right.

--- a/src/components/EntryPage.astro
+++ b/src/components/EntryPage.astro
@@ -1,0 +1,62 @@
+---
+import { render } from "astro:content";
+import ProseLayout from "../layouts/ProseLayout.astro";
+import AudioPlayer from "./AudioPlayer.astro";
+import { getReadingTimeMinutes } from "../utils/reading-time";
+import type { CollectionName } from "../utils/collections";
+
+// The single source of truth for how each collection's entries render.
+// Used by every published route and the /drafts/ preview route, so drafts
+// are faithful mirrors of what publishing will look like by construction.
+const PRESENTATION: Record<
+  CollectionName,
+  {
+    category?: string;
+    readingTime?: boolean;
+    hidePublishedOn?: boolean;
+    audioFallbackTitle?: string;
+  }
+> = {
+  blog: {
+    category: "blog",
+    readingTime: true,
+    audioFallbackTitle: "Listen to this blog",
+  },
+  poetry: { category: "poetry", audioFallbackTitle: "Listen to this poem" },
+  weeknotes: {
+    category: "weeknotes",
+    readingTime: true,
+    hidePublishedOn: true,
+  },
+  digitalGarden: {},
+  pages: {},
+};
+
+const { entry, collection, noindex } = Astro.props;
+const presentation = PRESENTATION[collection as CollectionName];
+const { Content } = await render(entry);
+const readingTimeMinutes = presentation.readingTime
+  ? getReadingTimeMinutes(entry.body)
+  : undefined;
+const audio = "audio" in entry.data ? entry.data.audio : undefined;
+const audioTitle =
+  "audioTitle" in entry.data ? entry.data.audioTitle : undefined;
+---
+
+<ProseLayout
+  frontmatter={entry.data}
+  category={presentation.category}
+  readingTimeMinutes={readingTimeMinutes}
+  hidePublishedOn={presentation.hidePublishedOn}
+  noindex={noindex}
+>
+  <Content />
+  {
+    audio && (
+      <AudioPlayer
+        src={audio}
+        title={audioTitle ?? presentation.audioFallbackTitle}
+      />
+    )
+  }
+</ProseLayout>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -37,15 +37,13 @@ function getCurrentSection(
   return { label: titleCase(firstSegment), href: `/${firstSegment}` };
 }
 
-// Draft previews live at /drafts/<section>/<slug> with no /drafts index;
+// Draft previews live at /drafts/<published-path> with no /drafts index;
 // resolve the underlying section so the nav matches the published version.
 // Skip the synthesized fallback for drafts — it would link to pages that
 // don't exist while the entry is unpublished.
-const isDraftPreview = /^\/drafts(\/|$)/.test(Astro.url.pathname);
-const current = getCurrentSection(
-  Astro.url.pathname.replace(/^\/drafts(?=\/|$)/, ""),
-  !isDraftPreview,
-);
+const strippedPath = Astro.url.pathname.replace(/^\/drafts(?=\/|$)/, "");
+const isDraftPreview = strippedPath !== Astro.url.pathname;
+const current = getCurrentSection(strippedPath, !isDraftPreview);
 const inMainNav =
   current && NAV_ITEMS.some((item) => item.href === current.href);
 const items: Section[] =

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -22,18 +22,30 @@ function titleCase(slug: string): string {
     .join(" ");
 }
 
-function getCurrentSection(path: string): Section | undefined {
+function getCurrentSection(
+  path: string,
+  allowFallback = true,
+): Section | undefined {
   const known = [...KNOWN_SECTIONS]
     .sort((a, b) => b.href.length - a.href.length)
     .find((s) => path === s.href || path.startsWith(`${s.href}/`));
   if (known) return known;
+  if (!allowFallback) return undefined;
 
   const firstSegment = path.split("/").filter(Boolean)[0];
   if (!firstSegment || firstSegment === "404") return undefined;
   return { label: titleCase(firstSegment), href: `/${firstSegment}` };
 }
 
-const current = getCurrentSection(Astro.url.pathname);
+// Draft previews live at /drafts/<section>/<slug> with no /drafts index;
+// resolve the underlying section so the nav matches the published version.
+// Skip the synthesized fallback for drafts — it would link to pages that
+// don't exist while the entry is unpublished.
+const isDraftPreview = /^\/drafts(\/|$)/.test(Astro.url.pathname);
+const current = getCurrentSection(
+  Astro.url.pathname.replace(/^\/drafts(?=\/|$)/, ""),
+  !isDraftPreview,
+);
 const inMainNav =
   current && NAV_ITEMS.some((item) => item.href === current.href);
 const items: Section[] =

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,6 @@
 ---
 import "/src/styles/global.css";
-const { class: className, title } = Astro.props;
+const { class: className, title, noindex } = Astro.props;
 ---
 
 <html lang="en">
@@ -10,6 +10,7 @@ const { class: className, title } = Astro.props;
     <link rel="stylesheet" type="text/css" href="/src/styles/global.css" />
     <meta name="generator" content={Astro.generator} />
     <meta name="author" content="Tanvi Bhakta" />
+    {noindex && <meta name="robots" content="noindex, nofollow" />}
 
     <!--For IndieAuth https://indieweb.org/IndieAuth-->
     <link href="https://github.com/tanvibhakta" rel="me" />

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -3,7 +3,7 @@ import Layout from "./Layout.astro";
 import Nav from "../components/Nav.astro";
 import { shortenWeeknoteTitles } from "../utils/date-helpers";
 
-const { frontmatter, category, readingTimeMinutes, hidePublishedOn } =
+const { frontmatter, category, readingTimeMinutes, hidePublishedOn, noindex } =
   Astro.props;
 
 let pageTitle = "";
@@ -38,6 +38,7 @@ const publishedOnIso = showPublishedOn ? publishedOn.toISOString() : undefined;
 
 <Layout
   title={pageTitle}
+  noindex={noindex}
   class="min-w-screen min-h-screen flex flex-col items-center text-stone-800 bg-stone-100"
 >
   <Nav />

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,6 +1,5 @@
 ---
-import { render } from "astro:content";
-import ProseLayout from "../layouts/ProseLayout.astro";
+import EntryPage from "../components/EntryPage.astro";
 import { getPublishedEntries } from "../utils/collections";
 
 export async function getStaticPaths() {
@@ -12,9 +11,6 @@ export async function getStaticPaths() {
 }
 
 const { page } = Astro.props;
-const { Content } = await render(page);
 ---
 
-<ProseLayout frontmatter={page.data}>
-  <Content />
-</ProseLayout>
+<EntryPage entry={page} collection="pages" />

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,9 +1,6 @@
 ---
-import { render } from "astro:content";
-import ProseLayout from "../../layouts/ProseLayout.astro";
-import AudioPlayer from "../../components/AudioPlayer.astro";
+import EntryPage from "../../components/EntryPage.astro";
 import { getPublishedEntries } from "../../utils/collections";
-import { getReadingTimeMinutes } from "../../utils/reading-time";
 
 export async function getStaticPaths() {
   const blogPosts = await getPublishedEntries("blog");
@@ -14,22 +11,6 @@ export async function getStaticPaths() {
 }
 
 const { blogPost } = Astro.props;
-const { Content } = await render(blogPost);
-const readingTimeMinutes = getReadingTimeMinutes(blogPost.body);
 ---
 
-<ProseLayout
-  frontmatter={blogPost.data}
-  category="blog"
-  readingTimeMinutes={readingTimeMinutes}
->
-  <Content />
-  {
-    blogPost.data.audio && (
-      <AudioPlayer
-        src={blogPost.data.audio}
-        title={blogPost.data.audioTitle ?? "Listen to this blog"}
-      />
-    )
-  }
-</ProseLayout>
+<EntryPage entry={blogPost} collection="blog" />

--- a/src/pages/digital-garden/[...slug].astro
+++ b/src/pages/digital-garden/[...slug].astro
@@ -1,6 +1,5 @@
 ---
-import { render } from "astro:content";
-import ProseLayout from "../../layouts/ProseLayout.astro";
+import EntryPage from "../../components/EntryPage.astro";
 import { getPublishedEntries } from "../../utils/collections";
 
 export async function getStaticPaths() {
@@ -12,9 +11,6 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
-const { Content } = await render(post);
 ---
 
-<ProseLayout frontmatter={post.data}>
-  <Content />
-</ProseLayout>
+<EntryPage entry={post} collection="digitalGarden" />

--- a/src/pages/drafts/[...slug].astro
+++ b/src/pages/drafts/[...slug].astro
@@ -1,32 +1,28 @@
 ---
-import { render } from "astro:content";
-import ProseLayout from "../../layouts/ProseLayout.astro";
-import AudioPlayer from "../../components/AudioPlayer.astro";
-import { getReadingTimeMinutes } from "../../utils/reading-time";
+import EntryPage from "../../components/EntryPage.astro";
+import {
+  COLLECTION_SEGMENTS,
+  getDraftEntries,
+  type CollectionName,
+} from "../../utils/collections";
 
 // Hidden-but-linkable review pages for `draft: true` entries in every
-// collection. Draft URLs are namespaced by collection (/drafts/blog/<id>)
-// so identically-named files in different collections can't collide.
+// collection. Draft URLs mirror the published ones with a /drafts prefix:
+// /drafts/blog/<id>, /drafts/poetry/<id>, and /drafts/<id> for root-level
+// pages — so stripping "/drafts" always yields the future published URL.
 // These pages are excluded from listings, RSS feeds, tag pages, and the
 // sitemap (see the sitemap filter in astro.config.mjs), and carry a
 // noindex meta tag.
 export async function getStaticPaths() {
-  const { getDraftEntries } = await import("../../utils/collections");
-  // collection name → URL segment (mirrors the published routes)
-  const segments = {
-    blog: "blog",
-    poetry: "poetry",
-    weeknotes: "weeknotes",
-    digitalGarden: "digital-garden",
-    pages: "pages",
-  } as const;
-
   const paths = [];
-  for (const [collection, segment] of Object.entries(segments)) {
-    const drafts = await getDraftEntries(collection as keyof typeof segments);
+  for (const collection of Object.keys(
+    COLLECTION_SEGMENTS,
+  ) as CollectionName[]) {
+    const segment = COLLECTION_SEGMENTS[collection];
+    const drafts = await getDraftEntries(collection);
     for (const entry of drafts) {
       paths.push({
-        params: { slug: `${segment}/${entry.id}` },
+        params: { slug: segment ? `${segment}/${entry.id}` : entry.id },
         props: { entry, collection },
       });
     }
@@ -35,28 +31,6 @@ export async function getStaticPaths() {
 }
 
 const { entry, collection } = Astro.props;
-const { Content } = await render(entry);
-
-// Mirror how each published route renders its entries.
-const category = ["blog", "poetry", "weeknotes"].includes(collection)
-  ? collection
-  : undefined;
-const readingTimeMinutes =
-  collection === "blog" || collection === "weeknotes"
-    ? getReadingTimeMinutes(entry.body)
-    : undefined;
-const audio = "audio" in entry.data ? entry.data.audio : undefined;
-const audioTitle =
-  "audioTitle" in entry.data ? entry.data.audioTitle : undefined;
 ---
 
-<ProseLayout
-  frontmatter={entry.data}
-  category={category}
-  readingTimeMinutes={readingTimeMinutes}
-  hidePublishedOn={collection === "weeknotes"}
-  noindex
->
-  <Content />
-  {audio && <AudioPlayer src={audio} title={audioTitle ?? "Listen to this"} />}
-</ProseLayout>
+<EntryPage entry={entry} collection={collection} noindex />

--- a/src/pages/drafts/[...slug].astro
+++ b/src/pages/drafts/[...slug].astro
@@ -1,0 +1,62 @@
+---
+import { render } from "astro:content";
+import ProseLayout from "../../layouts/ProseLayout.astro";
+import AudioPlayer from "../../components/AudioPlayer.astro";
+import { getReadingTimeMinutes } from "../../utils/reading-time";
+
+// Hidden-but-linkable review pages for `draft: true` entries in every
+// collection. Draft URLs are namespaced by collection (/drafts/blog/<id>)
+// so identically-named files in different collections can't collide.
+// These pages are excluded from listings, RSS feeds, tag pages, and the
+// sitemap (see the sitemap filter in astro.config.mjs), and carry a
+// noindex meta tag.
+export async function getStaticPaths() {
+  const { getDraftEntries } = await import("../../utils/collections");
+  // collection name → URL segment (mirrors the published routes)
+  const segments = {
+    blog: "blog",
+    poetry: "poetry",
+    weeknotes: "weeknotes",
+    digitalGarden: "digital-garden",
+    pages: "pages",
+  } as const;
+
+  const paths = [];
+  for (const [collection, segment] of Object.entries(segments)) {
+    const drafts = await getDraftEntries(collection as keyof typeof segments);
+    for (const entry of drafts) {
+      paths.push({
+        params: { slug: `${segment}/${entry.id}` },
+        props: { entry, collection },
+      });
+    }
+  }
+  return paths;
+}
+
+const { entry, collection } = Astro.props;
+const { Content } = await render(entry);
+
+// Mirror how each published route renders its entries.
+const category = ["blog", "poetry", "weeknotes"].includes(collection)
+  ? collection
+  : undefined;
+const readingTimeMinutes =
+  collection === "blog" || collection === "weeknotes"
+    ? getReadingTimeMinutes(entry.body)
+    : undefined;
+const audio = "audio" in entry.data ? entry.data.audio : undefined;
+const audioTitle =
+  "audioTitle" in entry.data ? entry.data.audioTitle : undefined;
+---
+
+<ProseLayout
+  frontmatter={entry.data}
+  category={category}
+  readingTimeMinutes={readingTimeMinutes}
+  hidePublishedOn={collection === "weeknotes"}
+  noindex
+>
+  <Content />
+  {audio && <AudioPlayer src={audio} title={audioTitle ?? "Listen to this"} />}
+</ProseLayout>

--- a/src/pages/poetry/[...slug].astro
+++ b/src/pages/poetry/[...slug].astro
@@ -1,7 +1,5 @@
 ---
-import { render } from "astro:content";
-import ProseLayout from "../../layouts/ProseLayout.astro";
-import AudioPlayer from "../../components/AudioPlayer.astro";
+import EntryPage from "../../components/EntryPage.astro";
 import { getPublishedEntries } from "../../utils/collections";
 
 export async function getStaticPaths() {
@@ -13,17 +11,6 @@ export async function getStaticPaths() {
 }
 
 const { poem } = Astro.props;
-const { Content } = await render(poem);
 ---
 
-<ProseLayout frontmatter={poem.data} category="poetry">
-  <Content />
-  {
-    poem.data.audio && (
-      <AudioPlayer
-        src={poem.data.audio}
-        title={poem.data.audioTitle ?? "Listen to this poem"}
-      />
-    )
-  }
-</ProseLayout>
+<EntryPage entry={poem} collection="poetry" />

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,5 +1,5 @@
 ---
-import { getPublishedEntries } from "../../utils/collections";
+import { getEntryPath, getPublishedEntries } from "../../utils/collections";
 import ProseLayout from "../../layouts/ProseLayout.astro";
 import { TAGS } from "../../content.config";
 import type { Tag } from "../../content.config";
@@ -14,22 +14,22 @@ const allPosts = [
   ...(await getPublishedEntries("blog")).map((p) => ({
     ...p,
     collection: "blog" as const,
-    href: `/blog/${p.id}`,
+    href: getEntryPath("blog", p.id),
   })),
   ...(await getPublishedEntries("weeknotes")).map((p) => ({
     ...p,
     collection: "weeknotes" as const,
-    href: `/weeknotes/${p.id}`,
+    href: getEntryPath("weeknotes", p.id),
   })),
   ...(await getPublishedEntries("poetry")).map((p) => ({
     ...p,
     collection: "poetry" as const,
-    href: `/poetry/${p.id}`,
+    href: getEntryPath("poetry", p.id),
   })),
   ...(await getPublishedEntries("digitalGarden")).map((p) => ({
     ...p,
     collection: "digital-garden" as const,
-    href: `/digital-garden/${p.id}`,
+    href: getEntryPath("digitalGarden", p.id),
   })),
 ];
 

--- a/src/pages/weeknotes/[...slug].astro
+++ b/src/pages/weeknotes/[...slug].astro
@@ -1,8 +1,6 @@
 ---
-import { render } from "astro:content";
-import ProseLayout from "../../layouts/ProseLayout.astro";
+import EntryPage from "../../components/EntryPage.astro";
 import { getPublishedEntries } from "../../utils/collections";
-import { getReadingTimeMinutes } from "../../utils/reading-time";
 
 export async function getStaticPaths() {
   const weeknotes = await getPublishedEntries("weeknotes");
@@ -13,15 +11,6 @@ export async function getStaticPaths() {
 }
 
 const { weeknote } = Astro.props;
-const { Content } = await render(weeknote);
-const readingTimeMinutes = getReadingTimeMinutes(weeknote.body);
 ---
 
-<ProseLayout
-  frontmatter={weeknote.data}
-  category="weeknotes"
-  readingTimeMinutes={readingTimeMinutes}
-  hidePublishedOn
->
-  <Content />
-</ProseLayout>
+<EntryPage entry={weeknote} collection="weeknotes" />

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,7 +1,27 @@
 import { getCollection } from "astro:content";
 import type { collections } from "../content.config";
 
-type CollectionName = keyof typeof collections;
+export type CollectionName = keyof typeof collections;
+
+/**
+ * Collection name → URL path segment. The single source of truth for where
+ * each collection's entries are served: published entries at
+ * /<segment>/<id>, drafts at /drafts/<segment>/<id>. `pages` entries are
+ * served at the site root, so their segment is empty.
+ */
+export const COLLECTION_SEGMENTS = {
+  blog: "blog",
+  poetry: "poetry",
+  weeknotes: "weeknotes",
+  digitalGarden: "digital-garden",
+  pages: "",
+} as const satisfies Record<CollectionName, string>;
+
+/** Site-relative URL for a published entry. */
+export function getEntryPath(collectionName: CollectionName, id: string) {
+  const segment = COLLECTION_SEGMENTS[collectionName];
+  return segment ? `/${segment}/${id}` : `/${id}`;
+}
 
 /**
  * Filter predicate that excludes draft entries.
@@ -19,8 +39,9 @@ export async function getPublishedEntries(collectionName: CollectionName) {
 
 /**
  * Get all draft entries from a collection. Used by the /drafts/ routes,
- * which build hidden-but-linkable review pages.
+ * which build hidden-but-linkable review pages. Defined as the negation of
+ * isPublished so the two provably partition every collection.
  */
 export async function getDraftEntries(collectionName: CollectionName) {
-  return getCollection(collectionName, ({ data }) => Boolean(data.draft));
+  return getCollection(collectionName, (entry) => !isPublished(entry));
 }

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -16,3 +16,11 @@ export const isPublished = ({ data }: { data: { draft?: boolean } }) =>
 export async function getPublishedEntries(collectionName: CollectionName) {
   return getCollection(collectionName, isPublished);
 }
+
+/**
+ * Get all draft entries from a collection. Used by the /drafts/ routes,
+ * which build hidden-but-linkable review pages.
+ */
+export async function getDraftEntries(collectionName: CollectionName) {
+  return getCollection(collectionName, ({ data }) => Boolean(data.draft));
+}

--- a/src/utils/feeds.ts
+++ b/src/utils/feeds.ts
@@ -3,7 +3,7 @@ import { getCollection, type CollectionEntry } from "astro:content";
 import MarkdownIt from "markdown-it";
 import sanitizeHtml from "sanitize-html";
 import { collections } from "../content.config";
-import { isPublished } from "./collections";
+import { getEntryPath, isPublished } from "./collections";
 
 const SITE_URL = "https://tanvibhakta.in";
 const SITE_TITLE = "Tanvi Bhakta";
@@ -98,7 +98,7 @@ export async function generateMainFeed() {
     items: sortedEntries.map((entry) => ({
       title: `[${capitalizeFirst(entry.collection)}] ${entry.data.title}`,
       pubDate: entry.data.publishedOn,
-      link: `/${entry.collection}/${entry.id}/`,
+      link: `${getEntryPath(entry.collection, entry.id)}/`,
       content: markdownToHtml(entry.body),
     })),
   });
@@ -123,7 +123,7 @@ export async function generateCollectionFeed(collectionName: CollectionName) {
     items: sortedEntries.map((entry) => ({
       title: entry.data.title,
       pubDate: entry.data.publishedOn,
-      link: `/${entry.collection}/${entry.id}/`,
+      link: `${getEntryPath(entry.collection, entry.id)}/`,
       content: markdownToHtml(entry.body),
     })),
   });

--- a/tests/linkChecker.test.ts
+++ b/tests/linkChecker.test.ts
@@ -66,6 +66,9 @@ async function findHtmlFiles(distDir: string): Promise<string[]> {
       const fullPath = path.join(dir, entry.name);
 
       if (entry.isDirectory()) {
+        // Draft previews (/drafts/) are work-in-progress by definition —
+        // dead links inside them must not block commits or deploys.
+        if (dir === distDir && entry.name === "drafts") continue;
         await scanDir(fullPath);
       } else if (entry.name.endsWith(".html")) {
         htmlFiles.push(fullPath);


### PR DESCRIPTION
## What

Entries with `draft: true` in any collection now build at a hidden-but-linkable URL — a shareable permalink for friends to review — while remaining completely absent from listing pages, tag pages, all RSS feeds, and the machine sitemap, and carrying `noindex, nofollow`.

Draft URLs mirror the published ones with a `/drafts` prefix, so stripping `/drafts` always yields the future published URL:

- `/drafts/blog/<id>`, `/drafts/poetry/<id>`, `/drafts/weeknotes/<id>`, `/drafts/digital-garden/<id>`
- `/drafts/<id>` for root-level `pages` entries

There is deliberately no `/drafts` index — it would enumerate all hidden drafts at a guessable URL. Previously `draft: true` meant the page wasn't built at all, so drafts had no URL.

## How

- `COLLECTION_SEGMENTS` / `getEntryPath()` in `src/utils/collections.ts` are the single source of truth for collection→URL mapping, consumed by the drafts route, tags page, and feeds (previously three private copies).
- A shared `EntryPage.astro` component renders entries for every published route *and* the drafts preview, so drafts mirror publishing by construction (per-collection category, reading time, audio fallback titles, weeknote date handling).
- `Layout`/`ProseLayout` accept a `noindex` prop; the sitemap filter excludes `/drafts/`.
- `Nav` resolves the underlying section for draft previews and skips its synthesized-section fallback there.
- The internal link checker skips `/drafts/` pages — drafts are WIP by definition and must not block commits/deploys.
- **Bonus fix:** the digital garden RSS feed's item links pointed at `/digitalGarden/<id>` and 404ed in production; they now build via `getEntryPath`.

Final commit adds *Repetition* as the first draft using this flow — drop it if you'd rather hold it back.

## Verification

- Full build + all 40 tests pass.
- Confirmed in `dist/`: 6 existing drafts build under `/drafts/`, none appear in any feed, sitemap, or listing; all carry noindex; digital garden feed links resolve; audio rendering on published posts is byte-identical in behavior.

Note: this makes existing `draft: true` posts (ranking-haleem-in-bangalore, review-project-hail-mary, unknown-figure, your-mac-apps-have-sqlite-databases-you-can-query, endorsement) reachable at unlisted URLs, where before they were fully unpublished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)