### PR TITLE
Derive page titles dynamically as {PageName} | {SiteName}

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,44 +1,5 @@
 ---
-import { SECTIONS, STANDALONE_PAGES } from "../content.config";
-
-type Section = { label: string; href: string };
-
-// Labels and membership come from the registry in content.config.ts; only
-// ordering and which items sit in the main nav are decided here. Home ("/")
-// is excluded — the site title link covers it.
-const KNOWN_SECTIONS: readonly Section[] = [
-  ...Object.values(SECTIONS),
-  ...Object.values(STANDALONE_PAGES),
-]
-  .filter(({ href }) => href !== "/")
-  .map(({ href, title }) => ({ href, label: title }));
-
-const NAV_HREFS = ["/work", "/blog", "/weeknotes"];
-const NAV_ITEMS: readonly Section[] = NAV_HREFS.flatMap(
-  (href) => KNOWN_SECTIONS.find((s) => s.href === href) ?? [],
-);
-
-function titleCase(slug: string): string {
-  return slug
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-}
-
-function getCurrentSection(
-  path: string,
-  allowFallback = true,
-): Section | undefined {
-  const known = [...KNOWN_SECTIONS]
-    .sort((a, b) => b.href.length - a.href.length)
-    .find((s) => path === s.href || path.startsWith(`${s.href}/`));
-  if (known) return known;
-  if (!allowFallback) return undefined;
-
-  const firstSegment = path.split("/").filter(Boolean)[0];
-  if (!firstSegment || firstSegment === "404") return undefined;
-  return { label: titleCase(firstSegment), href: `/${firstSegment}` };
-}
+import { NAV_ITEMS, getCurrentSection, type Section } from "../utils/sections";
 
 // Draft previews live at /drafts/<published-path> with no /drafts index;
 // resolve the underlying section so the nav matches the published version.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import "/src/styles/global.css";
 import { SITE_TAB_TITLE, SITE_DESCRIPTION } from "../utils/site";
+import { getPageName } from "../utils/sections";
 const {
   class: className,
   title,
@@ -9,7 +10,10 @@ const {
   noindex,
 } = Astro.props;
 
-const fullTitle = title ? `${title} | ${SITE_TAB_TITLE}` : SITE_TAB_TITLE;
+// An explicit title (e.g. "Post · Blog" from ProseLayout) wins; otherwise
+// derive the page name from the route. Homepage gets just the site name.
+const pageName = title || getPageName(Astro.url.pathname);
+const fullTitle = pageName ? `${pageName} | ${SITE_TAB_TITLE}` : SITE_TAB_TITLE;
 ---
 
 <html lang="en">
@@ -24,7 +28,7 @@ const fullTitle = title ? `${title} | ${SITE_TAB_TITLE}` : SITE_TAB_TITLE;
     <meta name="description" content={description} />
 
     <!-- Open Graph / share cards -->
-    <meta property="og:title" content={title || SITE_TAB_TITLE} />
+    <meta property="og:title" content={pageName || SITE_TAB_TITLE} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content={type} />
     <meta property="og:url" content={Astro.url.href} />

--- a/src/utils/sections.ts
+++ b/src/utils/sections.ts
@@ -1,0 +1,50 @@
+// Route → section-name logic shared by the nav (to highlight the current
+// section) and by Layout (to derive the document <title> as
+// "{PageName} | {SITE_TAB_TITLE}").
+import { SECTIONS, STANDALONE_PAGES } from "../content.config";
+
+export type Section = { label: string; href: string };
+
+// Labels and membership come from the registry in content.config.ts; only
+// ordering and which items sit in the main nav are decided here. Home ("/")
+// is excluded — the site title link covers it.
+export const KNOWN_SECTIONS: readonly Section[] = [
+  ...Object.values(SECTIONS),
+  ...Object.values(STANDALONE_PAGES),
+]
+  .filter(({ href }) => href !== "/")
+  .map(({ href, title }) => ({ href, label: title }));
+
+const NAV_HREFS = ["/work", "/blog", "/weeknotes"];
+export const NAV_ITEMS: readonly Section[] = NAV_HREFS.flatMap(
+  (href) => KNOWN_SECTIONS.find((s) => s.href === href) ?? [],
+);
+
+function titleCase(slug: string): string {
+  return slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+// The section a path belongs to: a known section if one matches, otherwise a
+// title-cased fallback from the first path segment. Undefined for the homepage.
+export function getCurrentSection(
+  path: string,
+  allowFallback = true,
+): Section | undefined {
+  const known = [...KNOWN_SECTIONS]
+    .sort((a, b) => b.href.length - a.href.length)
+    .find((s) => path === s.href || path.startsWith(`${s.href}/`));
+  if (known) return known;
+  if (!allowFallback) return undefined;
+
+  const firstSegment = path.split("/").filter(Boolean)[0];
+  if (!firstSegment || firstSegment === "404") return undefined;
+  return { label: titleCase(firstSegment), href: `/${firstSegment}` };
+}
+
+// The page name for the document <title>, or undefined for the homepage.
+export function getPageName(path: string): string | undefined {
+  return getCurrentSection(path)?.label;
+}

--- a/tests/page-titles.test.ts
+++ b/tests/page-titles.test.ts
@@ -33,6 +33,14 @@ describe("Page Titles", () => {
     expect(extractTitle(html)).toBe(SITE_TAB_TITLE);
   });
 
+  test("Work page derives its title from the route", async () => {
+    const html = await fs.promises.readFile(
+      path.join(distDir, "work/index.html"),
+      "utf8",
+    );
+    expect(extractTitle(html)).toBe("Work | Tanvi's Web Home");
+  });
+
   test("Blog index has correct title", async () => {
     const html = await fs.promises.readFile(
       path.join(distDir, "blog/index.html"),


### PR DESCRIPTION
Extracted from #105 per review — this is a site-wide `<title>` change independent of the notes content type, so it gets its own PR.

Extracts the route→section-name logic out of `Nav.astro` into a shared `src/utils/sections.ts` (single source of truth for `SITE_NAME` and the known sections, reused by the nav). `Layout.astro` now composes the document title from it:

- An explicit `title` prop still wins, preserving per-type suffixes like "Post | Blog".
- Any page without one derives `{PageName} | Tanvi's Web Home` from its route — e.g. /work, previously just "Tanvi's Web Home", is now "Work | Tanvi's Web Home". Unknown routes get a title-cased first path segment.
- The homepage stays bare.

Compared to the version in #105, this cherry-pick was rebased onto current main: it keeps the `allowFallback` parameter from the draft-previews work (#108) and drops the Notes section entry, which lands with #105 itself.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)