### PR TITLE
Add prev/next section footer to blog, poetry, and weeknote posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+Instructions for coding agents working in this repository.
+
+## Workflow
+
+- All work should happen in its own git worktree. Create one under
+  `.worktrees/<branch-name>` (`git worktree add .worktrees/<branch-name> -b <branch-name>`)
+  before making changes; never commit directly from the main checkout.
+
+## Project guidance
+
+See [CLAUDE.md](./CLAUDE.md) for architecture and development notes, and
+README.md for commands (dev server, build, test).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,5 +10,5 @@ Instructions for coding agents working in this repository.
 
 ## Project guidance
 
-See [CLAUDE.md](./CLAUDE.md) for architecture and development notes, and
-README.md for commands (dev server, build, test).
+See [CLAUDE.md](./CLAUDE.md), which imports this file and holds
+architecture notes and pointers to development commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Cross-tool agent rules (worktree workflow) live in AGENTS.md, imported here:
+
+@AGENTS.md
+
 ## Development Commands
 
 See README.md for the full list of commands including dev server, build, and test.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,26 @@ External redirects configured in `astro.config.mjs`:
 
 Uses Tailwind CSS 4.x with @tailwindcss/vite plugin and @tailwindcss/typography for content styling.
 
+**Reach for Tailwind utilities first.** New components should carry their
+styling in `class` attributes, not an Astro scoped `<style>` block. Scoped CSS
+is the exception, and each surviving block exists for a reason that a utility
+can't cover:
+
+- **Styling elements the component doesn't author.** `ul`/`li` coming out of a
+  slot or markdown have no `class` to hang a utility on — hence the bare
+  element selectors in `sitemap.astro` and `weeknotes/index.astro`, and the
+  `:global(h1)` override in `ProseLayout.astro`.
+- **Layouts with no utility equivalent**, e.g. `sitemap.astro`'s
+  `grid-template-columns: max-content 1fr` with `display: contents` rows.
+- **Winning a specificity fight cheaply.** Global CSS lives outside
+  `@layer`, so an unlayered rule beats every Tailwind utility. A scoped block
+  is also unlayered, which is why `.arrow-link`'s underline rules override
+  prose. In Tailwind, the same override needs `!` — see SiteFooter's
+  `text-inherit!`, which beats the global `a` color.
+
+Site-wide element defaults, `@theme`/`@plugin` config, and classes emitted by
+rehype plugins (`.anchor-link`) belong in `src/styles/global.css`.
+
 ### Code Quality
 
 - ESLint with TypeScript support configured in `eslint.config.js`

--- a/posts/blog/claude-is-bad-for-my-hedonistic-brain.md
+++ b/posts/blog/claude-is-bad-for-my-hedonistic-brain.md
@@ -1,8 +1,8 @@
 ---
 title: Claude is bad for my hedonist brain
-publishedOn: 2026-04-05
+publishedOn: 2026-04-05T19:44:32+05:30
 draft: false
-audioTitle: ''
+audioTitle: ""
 tags:
   - ai-usage
 ---

--- a/posts/blog/review-project-hail-mary.md
+++ b/posts/blog/review-project-hail-mary.md
@@ -1,6 +1,6 @@
 ---
 title: "Review: Project Hail Mary"
-publishedOn: 2026-04-05
+publishedOn: 2026-04-05T19:04:29+05:30
 draft: true
 tags:
   - reviews

--- a/posts/blog/unknown-figure.md
+++ b/posts/blog/unknown-figure.md
@@ -1,19 +1,19 @@
 ---
 title: how I deal with the heat
-publishedOn: 2026-04-05
+publishedOn: 2026-04-05T19:01:12+05:30
 draft: true
-audioTitle: ''
+audioTitle: ""
 ---
 
-I hate the cold. This is because I cannot deal with the cold. This is because I largely grew up in areas known for their heat and humidity, and thus developed all of the intuitions for dealing with the heat and none of the intuitions for dealing with the cold. 
+I hate the cold. This is because I cannot deal with the cold. This is because I largely grew up in areas known for their heat and humidity, and thus developed all of the intuitions for dealing with the heat and none of the intuitions for dealing with the cold.
 
 Climate change is very real and felt by all of us. In most places, climate change makes extremes more real - the cold gets colder and the hot gets hotter. Most of my friends spend entirely too much oxygen on complaining about the heat, while I frolic in the grass and have a generally great time. Here, I am attempting to put into words what some of my intuitions are, so that you too can worship the sun for the god she is.
 
 1. Sweat. Sweat is good for you, actually. It is your body’s natural mechanism to cool off. So please don’t use occlusives that obstruct your ability to sweat, or be in temperatures that don’t allow sweat to form at all. Sweat is a sign that things are working right. The next few points will support your body’s ability to cool itself best by sweating.
 2. Shower. It is the most normal thing in the world to shower three times a day in the summer on the coast. You shower once when you wake up, you shower once in the late afternoon/early evening when your day ends to wash off the sweat of the day, and you shower a third time just before bed to cool you off and set the tone for your sleep.
 
-    - the reason you must shower is because you sweat. The sweat cools your body but then leaves salt and dust caked onto your body, hampering its ability to sweat further. The more you shower, the easier your body can sweat and cool off.
-    - It is imperative, when showering in this heat, to do so with non-heated water. That is easier said than done, I know, and I often start my shower with warm water to not shock my body and acclimatise to the temperature. But try and end with cold water - it will help keep the sweat from forming immediately, and you will need lesser showers in the day overall. Having said that, hot showers are better than no showers.
-    - Showering doesn’t need to be a whole thing. I traveled very light when young a lot, and learnt the \*saat tambiyon nhaana\* - the seven tumbler shower - early on. You don’t need to redo your whole routine, just strip, throw cold water on yourself, towel off, clothes on.
+   - the reason you must shower is because you sweat. The sweat cools your body but then leaves salt and dust caked onto your body, hampering its ability to sweat further. The more you shower, the easier your body can sweat and cool off.
+   - It is imperative, when showering in this heat, to do so with non-heated water. That is easier said than done, I know, and I often start my shower with warm water to not shock my body and acclimatise to the temperature. But try and end with cold water - it will help keep the sweat from forming immediately, and you will need lesser showers in the day overall. Having said that, hot showers are better than no showers.
+   - Showering doesn’t need to be a whole thing. I traveled very light when young a lot, and learnt the \*saat tambiyon nhaana\* - the seven tumbler shower - early on. You don’t need to redo your whole routine, just strip, throw cold water on yourself, towel off, clothes on.
 
 3. Every time you shower, change your inner clothes. Even if they don’t feel dirty. Hell, if you don’t

--- a/posts/poetry/day-0.md
+++ b/posts/poetry/day-0.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 0"
-publishedOn: 2025-04-03
+publishedOn: 2025-04-03T09:00:00+05:30
 ---
 
 He is small and cute and  

--- a/posts/poetry/day-1.md
+++ b/posts/poetry/day-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 1"
-publishedOn: 2025-04-03
+publishedOn: 2025-04-03T09:01:00+05:30
 ---
 
 I left you behind  

--- a/posts/poetry/day-2.md
+++ b/posts/poetry/day-2.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 2"
-publishedOn: 2025-04-03
+publishedOn: 2025-04-03T09:02:00+05:30
 ---
 
 Talk to me, eternal love  

--- a/posts/poetry/day-3.md
+++ b/posts/poetry/day-3.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 3"
-publishedOn: 2025-04-03
+publishedOn: 2025-04-03T09:03:00+05:30
 ---
 
 I go up and down and have only one eye.  

--- a/posts/poetry/day-4.md
+++ b/posts/poetry/day-4.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 4"
-publishedOn: 2025-04-06
+publishedOn: 2025-04-06T09:00:00+05:30
 ---
 
 My ajjol didn't live with paintings  

--- a/posts/poetry/day-6-watermelon.md
+++ b/posts/poetry/day-6-watermelon.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 6: Watermelon"
-publishedOn: 2025-04-06
+publishedOn: 2025-04-06T09:01:00+05:30
 ---
 
 Splash  

--- a/posts/weeknotes/week-of-feb-1st-2026.md
+++ b/posts/weeknotes/week-of-feb-1st-2026.md
@@ -1,6 +1,6 @@
 ---
 title: "Week of Feb 1st, 2026"
-publishedOn: 2026-02-08
+publishedOn: 2026-02-08T22:10:03+05:30
 tags:
   - ai-usage
   - konkani

--- a/posts/weeknotes/week-of-feb-8th-2026.md
+++ b/posts/weeknotes/week-of-feb-8th-2026.md
@@ -1,6 +1,6 @@
 ---
 title: "Week of Feb 8th, 2026"
-publishedOn: 2026-02-08
+publishedOn: 2026-02-08T23:00:00+05:30
 ---
 
 ## Work

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -25,7 +25,9 @@ collections:
         direction: descending
     fields:
       - { label: Title, name: title, widget: string }
-      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ" }
+      # "{{now}}" prefills when the entry is first created in the editor, not
+      # when Publish is hit — adjust before publishing if the draft sat a while.
+      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ", default: "{{now}}" }
       - { label: Draft, name: draft, widget: boolean, default: true, required: false }
       - label: Audio
         name: audio
@@ -61,7 +63,9 @@ collections:
         direction: descending
     fields:
       - { label: Title, name: title, widget: string }
-      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ" }
+      # "{{now}}" prefills when the entry is first created in the editor, not
+      # when Publish is hit — adjust before publishing if the draft sat a while.
+      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ", default: "{{now}}" }
       - { label: Draft, name: draft, widget: boolean, default: true, required: false }
       - label: Audio
         name: audio
@@ -89,7 +93,9 @@ collections:
         direction: descending
     fields:
       - { label: Title, name: title, widget: string }
-      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ" }
+      # "{{now}}" prefills when the entry is first created in the editor, not
+      # when Publish is hit — adjust before publishing if the draft sat a while.
+      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ", default: "{{now}}" }
       - { label: Draft, name: draft, widget: boolean, default: true, required: false }
       - *tagsField
       - label: Body
@@ -113,7 +119,9 @@ collections:
         direction: descending
     fields:
       - { label: Title, name: title, widget: string }
-      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ" }
+      # "{{now}}" prefills when the entry is first created in the editor, not
+      # when Publish is hit — adjust before publishing if the draft sat a while.
+      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ", default: "{{now}}" }
       - { label: Last Updated, name: lastUpdatedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ", default: "{{now}}" }
       - { label: Description, name: description, widget: string, required: false }
       - { label: Draft, name: draft, widget: boolean, default: true, required: false }

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -25,7 +25,7 @@ collections:
         direction: descending
     fields:
       - { label: Title, name: title, widget: string }
-      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: false, format: YYYY-MM-DD }
+      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ" }
       - { label: Draft, name: draft, widget: boolean, default: true, required: false }
       - label: Audio
         name: audio
@@ -61,7 +61,7 @@ collections:
         direction: descending
     fields:
       - { label: Title, name: title, widget: string }
-      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: false, format: YYYY-MM-DD }
+      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ" }
       - { label: Draft, name: draft, widget: boolean, default: true, required: false }
       - label: Audio
         name: audio
@@ -89,7 +89,7 @@ collections:
         direction: descending
     fields:
       - { label: Title, name: title, widget: string }
-      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: false, format: YYYY-MM-DD }
+      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ" }
       - { label: Draft, name: draft, widget: boolean, default: true, required: false }
       - *tagsField
       - label: Body
@@ -113,8 +113,8 @@ collections:
         direction: descending
     fields:
       - { label: Title, name: title, widget: string }
-      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: false, format: YYYY-MM-DD }
-      - { label: Last Updated, name: lastUpdatedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: false, format: YYYY-MM-DD, default: "{{now}}" }
+      - { label: Publish Date, name: publishedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ" }
+      - { label: Last Updated, name: lastUpdatedOn, widget: datetime, date_format: YYYY-MM-DD, time_format: "HH:mm", format: "YYYY-MM-DDTHH:mm:ssZ", default: "{{now}}" }
       - { label: Description, name: description, widget: string, required: false }
       - { label: Draft, name: draft, widget: boolean, default: true, required: false }
       - *tagsField

--- a/scripts/new-content.ts
+++ b/scripts/new-content.ts
@@ -61,8 +61,10 @@ const COLLECTIONS = {
 
 type CollectionName = keyof typeof COLLECTIONS;
 
+// Seconds-precision ISO timestamp so same-day posts have a defined order.
+// Matches the CMS, which stores publishedOn as YYYY-MM-DDTHH:mm:ssZ.
 function formatDate(date: Date): string {
-  return date.toISOString().split("T")[0];
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
 // A naive local wall-clock timestamp ("YYYY-MM-DDTHH:mm:ss", no offset) stamped

--- a/src/components/ArrowLink.astro
+++ b/src/components/ArrowLink.astro
@@ -1,0 +1,13 @@
+---
+// Arrow-prefixed navigation link, e.g. "← all tags" or "next weeknote →".
+// "back" points the arrow left before the label; "forward" points it right after.
+interface Props {
+  href: string;
+  label: string;
+  direction?: "back" | "forward";
+}
+
+const { href, label, direction = "back" } = Astro.props;
+---
+
+<a href={href}>{direction === "back" ? `← ${label}` : `${label} →`}</a>

--- a/src/components/ArrowLink.astro
+++ b/src/components/ArrowLink.astro
@@ -1,13 +1,33 @@
 ---
-// Arrow-prefixed navigation link, e.g. "← all tags" or "next weeknote →".
-// "back" points the arrow left before the label; "forward" points it right after.
+// The site's directional navigation link: "← all tags", or with a
+// destination title, "next poem: Day 2 →". Owns everything that makes such
+// a link: the arrow (decorative, hidden from screen readers and glued to
+// its word so it never wraps alone), the "label: title" format, and the
+// nav-chrome styling — color only at rest, underline on hover — as opposed
+// to inline prose links, which stay persistently underlined.
 interface Props {
   href: string;
   label: string;
+  title?: string;
   direction?: "back" | "forward";
 }
 
-const { href, label, direction = "back" } = Astro.props;
+const { href, label, title, direction = "back" } = Astro.props;
+const text = title ? `${label}: ${title}` : label;
 ---
 
-<a href={href}>{direction === "back" ? `← ${label}` : `${label} →`}</a>
+<a href={href} class="arrow-link"
+  >{direction === "back" && <span aria-hidden="true">←&nbsp;</span>}{text}{
+    direction === "forward" && <span aria-hidden="true">&nbsp;→</span>
+  }</a
+>
+
+<style>
+  .arrow-link {
+    text-decoration: none;
+  }
+
+  .arrow-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/components/ArrowLink.astro
+++ b/src/components/ArrowLink.astro
@@ -1,10 +1,14 @@
 ---
-// The site's directional navigation link: "← all tags", or with a
-// destination title, "next poem: Day 2 →". Owns everything that makes such
-// a link: the arrow (decorative, hidden from screen readers and glued to
-// its word so it never wraps alone), the "label: title" format, and the
-// nav-chrome styling — color only at rest, underline on hover — as opposed
-// to inline prose links, which stay persistently underlined.
+// The site's directional navigation link. Without a destination title it is
+// one line, "← all tags". With one, the arrow stays with the label, which
+// becomes a quiet caption stacked over the destination itself: "next →"
+// above "giving baby tanvi what she wants". Only the title is the anchor, so
+// the link to the actual post behaves exactly like every other link on the
+// site; the caption is chrome. Owns everything that makes such a link: the
+// arrow (decorative, hidden from screen readers and glued to its word so it
+// never wraps alone), the label/title pairing, and the nav-chrome styling —
+// color only at rest, underline on hover — as opposed to inline prose links,
+// which stay persistently underlined.
 interface Props {
   href: string;
   label: string;
@@ -13,21 +17,27 @@ interface Props {
 }
 
 const { href, label, title, direction = "back" } = Astro.props;
-const text = title ? `${label}: ${title}` : label;
+const back = direction === "back";
+const LINK_CLASS = "no-underline hover:underline";
 ---
 
-<a href={href} class="arrow-link"
-  >{direction === "back" && <span aria-hidden="true">←&nbsp;</span>}{text}{
-    direction === "forward" && <span aria-hidden="true">&nbsp;→</span>
-  }</a
->
-
-<style>
-  .arrow-link {
-    text-decoration: none;
-  }
-
-  .arrow-link:hover {
-    text-decoration: underline;
-  }
-</style>
+{
+  title ? (
+    <>
+      <span class="block text-sm text-stone-500">
+        {back && <span aria-hidden="true">←&nbsp;</span>}
+        {label}
+        {!back && <span aria-hidden="true">&nbsp;→</span>}
+      </span>
+      <a href={href} class={LINK_CLASS}>
+        {title}
+      </a>
+    </>
+  ) : (
+    <a href={href} class={LINK_CLASS}>
+      {back && <span aria-hidden="true">←&nbsp;</span>}
+      {label}
+      {!back && <span aria-hidden="true">&nbsp;→</span>}
+    </a>
+  )
+}

--- a/src/components/EntryPage.astro
+++ b/src/components/EntryPage.astro
@@ -2,8 +2,13 @@
 import { render } from "astro:content";
 import ProseLayout from "../layouts/ProseLayout.astro";
 import AudioPlayer from "./AudioPlayer.astro";
+import SectionFooter from "./SectionFooter.astro";
 import { getReadingTimeMinutes } from "../utils/reading-time";
-import type { CollectionName } from "../utils/collections";
+import {
+  getEntryPath,
+  getPublishedEntries,
+  type CollectionName,
+} from "../utils/collections";
 
 // The single source of truth for how each collection's entries render.
 // Used by every published route and the /drafts/ preview route, so drafts
@@ -15,18 +20,27 @@ const PRESENTATION: Record<
     readingTime?: boolean;
     hidePublishedOn?: boolean;
     audioFallbackTitle?: string;
+    // Enables the prev/next section footer; the noun names the links,
+    // e.g. "weeknote" → "← previous weeknote" / "next weeknote →".
+    navNoun?: string;
   }
 > = {
   blog: {
     category: "blog",
     readingTime: true,
     audioFallbackTitle: "Listen to this blog",
+    navNoun: "post",
   },
-  poetry: { category: "poetry", audioFallbackTitle: "Listen to this poem" },
+  poetry: {
+    category: "poetry",
+    audioFallbackTitle: "Listen to this poem",
+    navNoun: "poem",
+  },
   weeknotes: {
     category: "weeknotes",
     readingTime: true,
     hidePublishedOn: true,
+    navNoun: "weeknote",
   },
   digitalGarden: {},
   pages: {},
@@ -41,6 +55,26 @@ const readingTimeMinutes = presentation.readingTime
 const audio = "audio" in entry.data ? entry.data.audio : undefined;
 const audioTitle =
   "audioTitle" in entry.data ? entry.data.audioTitle : undefined;
+
+// Chronological neighbours within the section. Drafts aren't in the
+// published list, so their previews render without a footer — they have
+// no position in the sequence until published.
+let prevHref: string | null = null;
+let nextHref: string | null = null;
+if (presentation.navNoun) {
+  const siblings = (
+    await getPublishedEntries(collection as "blog" | "poetry" | "weeknotes")
+  ).sort((a, b) => a.data.publishedOn.getTime() - b.data.publishedOn.getTime());
+  const index = siblings.findIndex((sibling) => sibling.id === entry.id);
+  const hrefAt = (i: number) =>
+    i >= 0 && siblings[i]
+      ? getEntryPath(collection as CollectionName, siblings[i].id)
+      : null;
+  if (index !== -1) {
+    prevHref = hrefAt(index - 1);
+    nextHref = hrefAt(index + 1);
+  }
+}
 ---
 
 <ProseLayout
@@ -56,6 +90,15 @@ const audioTitle =
       <AudioPlayer
         src={audio}
         title={audioTitle ?? presentation.audioFallbackTitle}
+      />
+    )
+  }
+  {
+    presentation.navNoun && (
+      <SectionFooter
+        noun={presentation.navNoun}
+        prevHref={prevHref}
+        nextHref={nextHref}
       />
     )
   }

--- a/src/components/EntryPage.astro
+++ b/src/components/EntryPage.astro
@@ -8,6 +8,7 @@ import {
   getPublishedEntriesSorted,
   type CollectionName,
   type DatedCollectionName,
+  type Neighbour,
 } from "../utils/collections";
 
 // The single source of truth for how each collection's entries render.
@@ -59,7 +60,6 @@ const audioTitle =
 // Chronological neighbours within the section. Drafts aren't in the
 // published list, so their previews render without a footer — they have
 // no position in the sequence until published.
-type Neighbour = { href: string; title: string };
 let prev: Neighbour | null = null;
 let next: Neighbour | null = null;
 if (presentation.navNoun) {
@@ -68,16 +68,18 @@ if (presentation.navNoun) {
     "oldestFirst",
   );
   const index = siblings.findIndex((sibling) => sibling.id === entry.id);
-  const neighbourAt = (i: number): Neighbour | null =>
-    i >= 0 && siblings[i]
+  const toNeighbour = (
+    sibling?: (typeof siblings)[number],
+  ): Neighbour | null =>
+    sibling
       ? {
-          href: getEntryPath(collection as CollectionName, siblings[i].id),
-          title: siblings[i].data.title,
+          href: getEntryPath(collection as CollectionName, sibling.id),
+          title: sibling.data.title,
         }
       : null;
   if (index !== -1) {
-    prev = neighbourAt(index - 1);
-    next = neighbourAt(index + 1);
+    prev = toNeighbour(siblings[index - 1]);
+    next = toNeighbour(siblings[index + 1]);
   }
 }
 ---

--- a/src/components/EntryPage.astro
+++ b/src/components/EntryPage.astro
@@ -44,6 +44,9 @@ const PRESENTATION: Record<
     navNoun: "weeknote",
   },
   digitalGarden: {},
+  // Notes render through NotesLayout, not EntryPage; this entry keeps the
+  // Record total over CollectionName and safe if notes ever gain drafts.
+  notes: {},
   pages: {},
 };
 

--- a/src/components/EntryPage.astro
+++ b/src/components/EntryPage.astro
@@ -59,20 +59,24 @@ const audioTitle =
 // Chronological neighbours within the section. Drafts aren't in the
 // published list, so their previews render without a footer — they have
 // no position in the sequence until published.
-let prevHref: string | null = null;
-let nextHref: string | null = null;
+type Neighbour = { href: string; title: string };
+let prev: Neighbour | null = null;
+let next: Neighbour | null = null;
 if (presentation.navNoun) {
   const siblings = (
     await getPublishedEntries(collection as "blog" | "poetry" | "weeknotes")
   ).sort((a, b) => a.data.publishedOn.getTime() - b.data.publishedOn.getTime());
   const index = siblings.findIndex((sibling) => sibling.id === entry.id);
-  const hrefAt = (i: number) =>
+  const neighbourAt = (i: number): Neighbour | null =>
     i >= 0 && siblings[i]
-      ? getEntryPath(collection as CollectionName, siblings[i].id)
+      ? {
+          href: getEntryPath(collection as CollectionName, siblings[i].id),
+          title: siblings[i].data.title,
+        }
       : null;
   if (index !== -1) {
-    prevHref = hrefAt(index - 1);
-    nextHref = hrefAt(index + 1);
+    prev = neighbourAt(index - 1);
+    next = neighbourAt(index + 1);
   }
 }
 ---
@@ -95,11 +99,7 @@ if (presentation.navNoun) {
   }
   {
     presentation.navNoun && (
-      <SectionFooter
-        noun={presentation.navNoun}
-        prevHref={prevHref}
-        nextHref={nextHref}
-      />
+      <SectionFooter noun={presentation.navNoun} prev={prev} next={next} />
     )
   }
 </ProseLayout>

--- a/src/components/EntryPage.astro
+++ b/src/components/EntryPage.astro
@@ -2,7 +2,6 @@
 import { render } from "astro:content";
 import ProseLayout from "../layouts/ProseLayout.astro";
 import AudioPlayer from "./AudioPlayer.astro";
-import SectionFooter from "./SectionFooter.astro";
 import { getReadingTimeMinutes } from "../utils/reading-time";
 import {
   getEntryPath,
@@ -87,6 +86,11 @@ if (presentation.navNoun) {
   readingTimeMinutes={readingTimeMinutes}
   hidePublishedOn={presentation.hidePublishedOn}
   noindex={noindex}
+  sectionNav={presentation.navNoun && {
+    noun: presentation.navNoun,
+    prev,
+    next,
+  }}
 >
   <Content />
   {
@@ -95,11 +99,6 @@ if (presentation.navNoun) {
         src={audio}
         title={audioTitle ?? presentation.audioFallbackTitle}
       />
-    )
-  }
-  {
-    presentation.navNoun && (
-      <SectionFooter noun={presentation.navNoun} prev={prev} next={next} />
     )
   }
 </ProseLayout>

--- a/src/components/EntryPage.astro
+++ b/src/components/EntryPage.astro
@@ -5,8 +5,9 @@ import AudioPlayer from "./AudioPlayer.astro";
 import { getReadingTimeMinutes } from "../utils/reading-time";
 import {
   getEntryPath,
-  getPublishedEntries,
+  getPublishedEntriesSorted,
   type CollectionName,
+  type DatedCollectionName,
 } from "../utils/collections";
 
 // The single source of truth for how each collection's entries render.
@@ -62,9 +63,10 @@ type Neighbour = { href: string; title: string };
 let prev: Neighbour | null = null;
 let next: Neighbour | null = null;
 if (presentation.navNoun) {
-  const siblings = (
-    await getPublishedEntries(collection as "blog" | "poetry" | "weeknotes")
-  ).sort((a, b) => a.data.publishedOn.getTime() - b.data.publishedOn.getTime());
+  const siblings = await getPublishedEntriesSorted(
+    collection as DatedCollectionName,
+    "oldestFirst",
+  );
   const index = siblings.findIndex((sibling) => sibling.id === entry.id);
   const neighbourAt = (i: number): Neighbour | null =>
     i >= 0 && siblings[i]

--- a/src/components/SectionFooter.astro
+++ b/src/components/SectionFooter.astro
@@ -21,7 +21,8 @@ const { noun, prev, next } = Astro.props;
         {prev && (
           <ArrowLink
             href={prev.href}
-            label={`previous ${noun}: ${prev.title}`}
+            label={`previous ${noun}`}
+            title={prev.title}
           />
         )}
       </span>
@@ -29,7 +30,8 @@ const { noun, prev, next } = Astro.props;
         {next && (
           <ArrowLink
             href={next.href}
-            label={`next ${noun}: ${next.title}`}
+            label={`next ${noun}`}
+            title={next.title}
             direction="forward"
           />
         )}
@@ -48,16 +50,5 @@ const { noun, prev, next } = Astro.props;
 
   .section-footer > span:last-child {
     text-align: right;
-  }
-
-  /* Navigation chrome, not an inline prose link: the prose wrapper's
-     always-on underline reads wrong here. Like the site nav and tags,
-     rely on the link color and underline only on hover. */
-  .section-footer :global(a) {
-    text-decoration: none;
-  }
-
-  .section-footer :global(a:hover) {
-    text-decoration: underline;
   }
 </style>

--- a/src/components/SectionFooter.astro
+++ b/src/components/SectionFooter.astro
@@ -1,28 +1,35 @@
 ---
 // Chronological prev/next navigation shown at the bottom of every post in a
-// section, e.g. "← previous weeknote" / "next weeknote →".
+// section, e.g. "← previous weeknote: Week of Dec 11th, 2024".
 import ArrowLink from "./ArrowLink.astro";
+
+type Neighbour = { href: string; title: string };
 
 interface Props {
   noun: string;
-  prevHref?: string | null;
-  nextHref?: string | null;
+  prev?: Neighbour | null;
+  next?: Neighbour | null;
 }
 
-const { noun, prevHref, nextHref } = Astro.props;
+const { noun, prev, next } = Astro.props;
 ---
 
 {
-  (prevHref || nextHref) && (
+  (prev || next) && (
     <nav class="section-footer" aria-label={`${noun} navigation`}>
       <span>
-        {prevHref && <ArrowLink href={prevHref} label={`previous ${noun}`} />}
+        {prev && (
+          <ArrowLink
+            href={prev.href}
+            label={`previous ${noun}: ${prev.title}`}
+          />
+        )}
       </span>
       <span>
-        {nextHref && (
+        {next && (
           <ArrowLink
-            href={nextHref}
-            label={`next ${noun}`}
+            href={next.href}
+            label={`next ${noun}: ${next.title}`}
             direction="forward"
           />
         )}
@@ -37,5 +44,9 @@ const { noun, prevHref, nextHref } = Astro.props;
     justify-content: space-between;
     gap: 1rem;
     margin-top: 2rem;
+  }
+
+  .section-footer > span:last-child {
+    text-align: right;
   }
 </style>

--- a/src/components/SectionFooter.astro
+++ b/src/components/SectionFooter.astro
@@ -49,4 +49,15 @@ const { noun, prev, next } = Astro.props;
   .section-footer > span:last-child {
     text-align: right;
   }
+
+  /* Navigation chrome, not an inline prose link: the prose wrapper's
+     always-on underline reads wrong here. Like the site nav and tags,
+     rely on the link color and underline only on hover. */
+  .section-footer :global(a) {
+    text-decoration: none;
+  }
+
+  .section-footer :global(a:hover) {
+    text-decoration: underline;
+  }
 </style>

--- a/src/components/SectionFooter.astro
+++ b/src/components/SectionFooter.astro
@@ -2,8 +2,7 @@
 // Chronological prev/next navigation shown at the bottom of every post in a
 // section, e.g. "← previous weeknote: Week of Dec 11th, 2024".
 import ArrowLink from "./ArrowLink.astro";
-
-type Neighbour = { href: string; title: string };
+import type { Neighbour } from "../utils/collections";
 
 interface Props {
   noun: string;

--- a/src/components/SectionFooter.astro
+++ b/src/components/SectionFooter.astro
@@ -1,0 +1,41 @@
+---
+// Chronological prev/next navigation shown at the bottom of every post in a
+// section, e.g. "← previous weeknote" / "next weeknote →".
+import ArrowLink from "./ArrowLink.astro";
+
+interface Props {
+  noun: string;
+  prevHref?: string | null;
+  nextHref?: string | null;
+}
+
+const { noun, prevHref, nextHref } = Astro.props;
+---
+
+{
+  (prevHref || nextHref) && (
+    <nav class="section-footer" aria-label={`${noun} navigation`}>
+      <span>
+        {prevHref && <ArrowLink href={prevHref} label={`previous ${noun}`} />}
+      </span>
+      <span>
+        {nextHref && (
+          <ArrowLink
+            href={nextHref}
+            label={`next ${noun}`}
+            direction="forward"
+          />
+        )}
+      </span>
+    </nav>
+  )
+}
+
+<style>
+  .section-footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 2rem;
+  }
+</style>

--- a/src/components/SectionFooter.astro
+++ b/src/components/SectionFooter.astro
@@ -1,6 +1,8 @@
 ---
 // Chronological prev/next navigation shown at the bottom of every post in a
-// section, e.g. "← previous weeknote: Week of Dec 11th, 2024".
+// section: a "previous"/"next" caption over the neighbouring post's title,
+// one at each edge. The captions stay bare because the nav's own label
+// carries the noun ("weeknote navigation") for screen readers.
 import ArrowLink from "./ArrowLink.astro";
 import type { Neighbour } from "../utils/collections";
 
@@ -21,18 +23,14 @@ const { noun, prev, next } = Astro.props;
     >
       <span>
         {prev && (
-          <ArrowLink
-            href={prev.href}
-            label={`previous ${noun}`}
-            title={prev.title}
-          />
+          <ArrowLink href={prev.href} label="previous" title={prev.title} />
         )}
       </span>
       <span class="text-right">
         {next && (
           <ArrowLink
             href={next.href}
-            label={`next ${noun}`}
+            label="next"
             title={next.title}
             direction="forward"
           />

--- a/src/components/SectionFooter.astro
+++ b/src/components/SectionFooter.astro
@@ -15,7 +15,10 @@ const { noun, prev, next } = Astro.props;
 
 {
   (prev || next) && (
-    <nav class="section-footer" aria-label={`${noun} navigation`}>
+    <nav
+      class="mt-8 flex justify-between gap-4"
+      aria-label={`${noun} navigation`}
+    >
       <span>
         {prev && (
           <ArrowLink
@@ -25,7 +28,7 @@ const { noun, prev, next } = Astro.props;
           />
         )}
       </span>
-      <span>
+      <span class="text-right">
         {next && (
           <ArrowLink
             href={next.href}
@@ -38,16 +41,3 @@ const { noun, prev, next } = Astro.props;
     </nav>
   )
 }
-
-<style>
-  .section-footer {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-top: 2rem;
-  }
-
-  .section-footer > span:last-child {
-    text-align: right;
-  }
-</style>

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -4,15 +4,11 @@ import Nav from "../components/Nav.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import SectionFooter from "../components/SectionFooter.astro";
 import { shortenWeeknoteTitles, formatLongDate } from "../utils/date-helpers";
+import type { SectionNav } from "../utils/collections";
 
-const {
-  frontmatter,
-  category,
-  readingTimeMinutes,
-  hidePublishedOn,
-  noindex,
-  sectionNav,
-} = Astro.props;
+const { frontmatter, category, readingTimeMinutes, hidePublishedOn, noindex } =
+  Astro.props;
+const sectionNav: SectionNav | undefined = Astro.props.sectionNav || undefined;
 
 const publishedOn: Date | undefined = frontmatter?.publishedOn;
 const showPublishedOn = !hidePublishedOn && publishedOn instanceof Date;

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -2,10 +2,17 @@
 import Layout from "./Layout.astro";
 import Nav from "../components/Nav.astro";
 import SiteFooter from "../components/SiteFooter.astro";
+import SectionFooter from "../components/SectionFooter.astro";
 import { shortenWeeknoteTitles, formatLongDate } from "../utils/date-helpers";
 
-const { frontmatter, category, readingTimeMinutes, hidePublishedOn, noindex } =
-  Astro.props;
+const {
+  frontmatter,
+  category,
+  readingTimeMinutes,
+  hidePublishedOn,
+  noindex,
+  sectionNav,
+} = Astro.props;
 
 const publishedOn: Date | undefined = frontmatter?.publishedOn;
 const showPublishedOn = !hidePublishedOn && publishedOn instanceof Date;
@@ -64,18 +71,43 @@ if (frontmatter?.title) {
     }
     <slot />
     {
+      // A <footer> nested in the <article> is scoped to the post itself,
+      // so post metadata like tags belongs here — distinct from the
+      // page-level <footer> below.
       frontmatter?.tags && frontmatter.tags.length > 0 && (
-        <div class="tags">
+        <footer class="tags">
           {frontmatter.tags.map((tag: string) => (
             <a href={`/tags/${tag}`} class="tag">
               {tag}
             </a>
           ))}
-        </div>
+        </footer>
       )
     }
   </article>
-  <SiteFooter />
+  {
+    // Both footers live in one bottom-pinned group: a lone mt-auto pins its
+    // element to the viewport bottom, but two of them split the free space
+    // between themselves instead. So the group carries the mt-auto, and
+    // SiteFooter's own is inert here because the group is only as tall as
+    // its contents.
+  }
+  <div class="mt-auto self-stretch flex flex-col items-center">
+    {
+      // Outside the <article>, this <footer> is scoped to the page rather
+      // than to the post.
+      sectionNav && (sectionNav.prev || sectionNav.next) && (
+        <footer class="self-stretch mx-8 md:self-center md:w-1/2 prose md:prose-lg prose-stone">
+          <SectionFooter
+            noun={sectionNav.noun}
+            prev={sectionNav.prev}
+            next={sectionNav.next}
+          />
+        </footer>
+      )
+    }
+    <SiteFooter />
+  </div>
 </Layout>
 
 <style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,11 +1,9 @@
 ---
-import { getPublishedEntries } from "../../utils/collections";
+import { getPublishedEntriesSorted } from "../../utils/collections";
 import ProseLayout from "../../layouts/ProseLayout.astro";
 import { SECTIONS } from "../../content.config";
 
-const sortedBlogPosts = (await getPublishedEntries("blog")).sort(
-  (a, b) => b.data.publishedOn.getTime() - a.data.publishedOn.getTime(),
-);
+const sortedBlogPosts = await getPublishedEntriesSorted("blog");
 
 const frontmatter = SECTIONS.blog;
 ---

--- a/src/pages/poetry/index.astro
+++ b/src/pages/poetry/index.astro
@@ -2,14 +2,10 @@
 import { render } from "astro:content";
 import ProseLayout from "../../layouts/ProseLayout.astro";
 import AudioPlayer from "../../components/AudioPlayer.astro";
-import { getPublishedEntries } from "../../utils/collections";
+import { getPublishedEntriesSorted } from "../../utils/collections";
 import { SECTIONS } from "../../content.config";
 
-const allPoetry = await getPublishedEntries("poetry");
-
-const sorted = allPoetry.sort(
-  (a, b) => a.data.publishedOn.getTime() - b.data.publishedOn.getTime(),
-);
+const sorted = await getPublishedEntriesSorted("poetry", "oldestFirst");
 
 const renderedPoetry = await Promise.all(
   sorted.map(async (poem) => ({

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -4,6 +4,7 @@ import { TAGGED_COLLECTIONS } from "../../utils/tagged-collections";
 import { SECTIONS } from "../../content.config";
 import ProseLayout from "../../layouts/ProseLayout.astro";
 import { formatLongDate, formatNoteTimestamp } from "../../utils/date-helpers";
+import ArrowLink from "../../components/ArrowLink.astro";
 
 export async function getStaticPaths() {
   return (await getAllTags()).map((tag) => ({ params: { tag } }));
@@ -28,7 +29,7 @@ const frontmatter = { title: tag };
 ---
 
 <ProseLayout frontmatter={frontmatter}>
-  <p><a href="/tags">← all tags</a></p>
+  <p><ArrowLink href="/tags" label="all tags" /></p>
   {
     sections.map(({ label, posts }) => (
       <section>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,5 +1,9 @@
 ---
-import { getAllTaggedPosts, getAllTags } from "../../utils/collections";
+import {
+  getAllTaggedPosts,
+  getAllTags,
+  newestFirst,
+} from "../../utils/collections";
 import { TAGGED_COLLECTIONS } from "../../utils/tagged-collections";
 import { SECTIONS } from "../../content.config";
 import ProseLayout from "../../layouts/ProseLayout.astro";
@@ -13,10 +17,6 @@ export async function getStaticPaths() {
 const { tag } = Astro.params as { tag: string };
 
 const allPosts = await getAllTaggedPosts();
-const newestFirst = (
-  a: (typeof allPosts)[number],
-  b: (typeof allPosts)[number],
-) => b.data.publishedOn.getTime() - a.data.publishedOn.getTime();
 
 const sections = TAGGED_COLLECTIONS.map((name) => ({
   label: SECTIONS[name].title,

--- a/src/pages/weeknotes/index.astro
+++ b/src/pages/weeknotes/index.astro
@@ -1,11 +1,9 @@
 ---
 import { render } from "astro:content";
 import ProseLayout from "../../layouts/ProseLayout.astro";
-import { getPublishedEntries } from "../../utils/collections";
+import { getPublishedEntriesSorted } from "../../utils/collections";
 import { SECTIONS } from "../../content.config";
-const sortedWeeknotes = (await getPublishedEntries("weeknotes")).sort(
-  (a, b) => b.data.publishedOn.getTime() - a.data.publishedOn.getTime(),
-);
+const sortedWeeknotes = await getPublishedEntriesSorted("weeknotes");
 
 const latestWeeknote = sortedWeeknotes[0];
 const previousWeeknotes = sortedWeeknotes.slice(1);

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -32,6 +32,41 @@ export async function getPublishedEntries<C extends CollectionName>(
   return getCollection(collectionName, isPublished);
 }
 
+/** Collections whose entries carry a publishedOn date (all but `pages`). */
+export type DatedCollectionName = Exclude<CollectionName, "pages">;
+
+type DatedEntry = { id: string; data: { publishedOn: Date } };
+
+/**
+ * Ascending chronological comparator, the single home for publishedOn
+ * ordering. Ties (identical timestamps, e.g. legacy date-only frontmatter)
+ * break on entry id so ordering is deterministic rather than dependent on
+ * file discovery order.
+ */
+export function byPublishedOn(a: DatedEntry, b: DatedEntry): number {
+  return (
+    a.data.publishedOn.getTime() - b.data.publishedOn.getTime() ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+/** Descending variant of byPublishedOn, for listings and feeds. */
+export function newestFirst(a: DatedEntry, b: DatedEntry): number {
+  return byPublishedOn(b, a);
+}
+
+/**
+ * Published entries in chronological order. "newestFirst" (the default)
+ * matches listing pages and feeds; "oldestFirst" is prev/next reading order.
+ */
+export async function getPublishedEntriesSorted<C extends DatedCollectionName>(
+  collectionName: C,
+  order: "newestFirst" | "oldestFirst" = "newestFirst",
+) {
+  const entries = await getPublishedEntries(collectionName);
+  return entries.sort(order === "newestFirst" ? newestFirst : byPublishedOn);
+}
+
 /**
  * Get all draft entries from a collection. Used by the /drafts/ routes,
  * which build hidden-but-linkable review pages. Defined as the negation of

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -35,6 +35,18 @@ export async function getPublishedEntries<C extends CollectionName>(
 /** Collections whose entries carry a publishedOn date (all but `pages`). */
 export type DatedCollectionName = Exclude<CollectionName, "pages">;
 
+/**
+ * The prev/next contract for section navigation: produced by EntryPage
+ * (hrefs via getEntryPath), passed through ProseLayout, rendered by
+ * SectionFooter.
+ */
+export type Neighbour = { href: string; title: string };
+export type SectionNav = {
+  noun: string;
+  prev: Neighbour | null;
+  next: Neighbour | null;
+};
+
 type DatedEntry = { id: string; data: { publishedOn: Date } };
 
 /**

--- a/src/utils/feeds.ts
+++ b/src/utils/feeds.ts
@@ -6,6 +6,7 @@ import { collections } from "../content.config";
 import {
   getEntryPath,
   isPublished,
+  newestFirst,
   type CollectionName,
 } from "./collections";
 import { formatLongDate, noteWallClockToInstant } from "./date-helpers";
@@ -118,13 +119,7 @@ export async function generateMainFeed() {
   const allEntries = await getAllCollectionEntries();
 
   // Sort by date and limit
-  const sortedEntries = allEntries
-    .sort(
-      (a, b) =>
-        new Date(b.data.publishedOn).getTime() -
-        new Date(a.data.publishedOn).getTime(),
-    )
-    .slice(0, FEED_LIMIT);
+  const sortedEntries = allEntries.sort(newestFirst).slice(0, FEED_LIMIT);
 
   return rss({
     title: SITE_TITLE,
@@ -149,13 +144,7 @@ export async function generateCollectionFeed(
     collectionName === "notes" ? await getNoteNumbers() : null;
 
   // Sort by date and limit
-  const sortedEntries = entries
-    .sort(
-      (a, b) =>
-        new Date(b.data.publishedOn).getTime() -
-        new Date(a.data.publishedOn).getTime(),
-    )
-    .slice(0, FEED_LIMIT);
+  const sortedEntries = entries.sort(newestFirst).slice(0, FEED_LIMIT);
 
   return rss({
     title: `${SITE_TITLE} - ${capitalizeFirst(collectionName)}`,

--- a/tests/collections.test.ts
+++ b/tests/collections.test.ts
@@ -1,13 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import {
-  byPublishedOn,
-  newestFirst,
-  getPublishedEntriesSorted,
-} from "../src/utils/collections";
+
+// The real getCollection is overloaded against Astro's generated collection
+// types; the tests drive it with plain fixture entries, so the mock uses this
+// looser signature instead (same pattern as feeds.test.ts).
+type TestEntry = {
+  id: string;
+  data: { publishedOn: Date; draft?: boolean };
+};
+
+const mocks = vi.hoisted(() => ({
+  getCollection: vi.fn(
+    async (
+      _name: string,
+      filter?: (entry: {
+        id: string;
+        data: { publishedOn: Date; draft?: boolean };
+      }) => boolean,
+    ) => {
+      const entries: TestEntry[] = [];
+      return filter ? entries.filter(filter) : entries;
+    },
+  ),
+}));
 
 // Mock the astro:content module
 vi.mock("astro:content", () => ({
-  getCollection: vi.fn(),
+  getCollection: mocks.getCollection,
 }));
 
 // Mock the content config to avoid import issues
@@ -17,6 +35,7 @@ vi.mock("../src/content.config", () => ({
     weeknotes: {},
     poetry: {},
     digitalGarden: {},
+    notes: {},
     pages: {},
   },
   COLLECTION_SEGMENTS: {
@@ -24,6 +43,7 @@ vi.mock("../src/content.config", () => ({
     weeknotes: "weeknotes",
     poetry: "poetry",
     digitalGarden: "digital-garden",
+    notes: "notes",
     pages: "",
   },
   SECTIONS: {
@@ -38,9 +58,13 @@ vi.mock("../src/content.config", () => ({
   },
 }));
 
-import { getCollection } from "astro:content";
+import {
+  byPublishedOn,
+  newestFirst,
+  getPublishedEntriesSorted,
+} from "../src/utils/collections";
 
-const entry = (id: string, publishedOn: string, draft = false) => ({
+const entry = (id: string, publishedOn: string, draft = false): TestEntry => ({
   id,
   data: { publishedOn: new Date(publishedOn), draft },
 });
@@ -90,16 +114,14 @@ describe("newestFirst", () => {
 
 describe("getPublishedEntriesSorted", () => {
   beforeEach(() => {
-    vi.mocked(getCollection).mockImplementation(
-      (_name: string, filter?: (entry: unknown) => boolean) => {
-        const entries = [
-          entry("draft-post", "2026-05-01", true),
-          entry("old-post", "2025-04-03"),
-          entry("new-post", "2026-02-08"),
-        ];
-        return Promise.resolve(filter ? entries.filter(filter) : entries);
-      },
-    );
+    mocks.getCollection.mockImplementation(async (_name, filter) => {
+      const entries = [
+        entry("draft-post", "2026-05-01", true),
+        entry("old-post", "2025-04-03"),
+        entry("new-post", "2026-02-08"),
+      ];
+      return filter ? entries.filter(filter) : entries;
+    });
   });
 
   it("defaults to newest first and excludes drafts", async () => {

--- a/tests/collections.test.ts
+++ b/tests/collections.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  byPublishedOn,
+  newestFirst,
+  getPublishedEntriesSorted,
+} from "../src/utils/collections";
+
+// Mock the astro:content module
+vi.mock("astro:content", () => ({
+  getCollection: vi.fn(),
+}));
+
+// Mock the content config to avoid import issues
+vi.mock("../src/content.config", () => ({
+  collections: {
+    blog: {},
+    weeknotes: {},
+    poetry: {},
+    digitalGarden: {},
+    pages: {},
+  },
+  COLLECTION_SEGMENTS: {
+    blog: "blog",
+    weeknotes: "weeknotes",
+    poetry: "poetry",
+    digitalGarden: "digital-garden",
+    pages: "",
+  },
+  SECTIONS: {
+    blog: { href: "/blog", title: "Blog", description: "" },
+    poetry: { href: "/poetry", title: "Poetry", description: "" },
+    weeknotes: { href: "/weeknotes", title: "Weeknotes", description: "" },
+    digitalGarden: {
+      href: "/digital-garden",
+      title: "Digital Garden",
+      description: "",
+    },
+  },
+}));
+
+import { getCollection } from "astro:content";
+
+const entry = (id: string, publishedOn: string, draft = false) => ({
+  id,
+  data: { publishedOn: new Date(publishedOn), draft },
+});
+
+describe("byPublishedOn", () => {
+  it("orders entries chronologically, oldest first", () => {
+    const posts = [
+      entry("newest", "2026-02-08T23:00:00+05:30"),
+      entry("oldest", "2025-04-03"),
+      entry("middle", "2025-04-06"),
+    ];
+    expect(posts.sort(byPublishedOn).map((p) => p.id)).toEqual([
+      "oldest",
+      "middle",
+      "newest",
+    ]);
+  });
+
+  it("breaks identical-timestamp ties on id, not input order", () => {
+    // Legacy date-only frontmatter all parses to midnight UTC; the id
+    // tie-break keeps ordering deterministic regardless of file discovery.
+    const posts = [
+      entry("day-2", "2025-04-03"),
+      entry("day-0", "2025-04-03"),
+      entry("day-1", "2025-04-03"),
+    ];
+    expect(posts.sort(byPublishedOn).map((p) => p.id)).toEqual([
+      "day-0",
+      "day-1",
+      "day-2",
+    ]);
+  });
+});
+
+describe("newestFirst", () => {
+  it("is the exact reverse of byPublishedOn", () => {
+    const posts = [
+      entry("a", "2025-01-01"),
+      entry("b", "2026-01-01"),
+      entry("c", "2025-06-01"),
+    ];
+    const ascending = [...posts].sort(byPublishedOn).map((p) => p.id);
+    const descending = [...posts].sort(newestFirst).map((p) => p.id);
+    expect(descending).toEqual(ascending.toReversed());
+  });
+});
+
+describe("getPublishedEntriesSorted", () => {
+  beforeEach(() => {
+    vi.mocked(getCollection).mockImplementation(
+      (_name: string, filter?: (entry: unknown) => boolean) => {
+        const entries = [
+          entry("draft-post", "2026-05-01", true),
+          entry("old-post", "2025-04-03"),
+          entry("new-post", "2026-02-08"),
+        ];
+        return Promise.resolve(filter ? entries.filter(filter) : entries);
+      },
+    );
+  });
+
+  it("defaults to newest first and excludes drafts", async () => {
+    const sorted = await getPublishedEntriesSorted("blog");
+    expect(sorted.map((p) => p.id)).toEqual(["new-post", "old-post"]);
+  });
+
+  it("returns oldest first for prev/next reading order", async () => {
+    const sorted = await getPublishedEntriesSorted("blog", "oldestFirst");
+    expect(sorted.map((p) => p.id)).toEqual(["old-post", "new-post"]);
+  });
+});


### PR DESCRIPTION
Every blog post, poem, and weeknote now ends with chronological prev/next
navigation, and the ordering it relies on is centralised so listings, feeds,
and this nav all agree.

## The nav itself

Each side reads as two lines: a small grey "← previous" caption over the
neighbouring post's title, mirrored to the right edge for next. Only the
title is an anchor, so the link to the post keeps the plain link behaviour of
the rest of the site — colour at rest, underline on hover — with no clickable
chrome around it. The arrows are decorative and hidden from screen readers;
the captions drop their noun because the nav's own label ("weeknote
navigation") already says which section it moves through.

`ArrowLink` owns the concept and still renders the one-line form, "← all
tags", where no destination title is passed.

## Ordering

`publishedOn` now carries a time, written by both the CMS and the
new-content script, so posts published on the same day have an explicit
order instead of an incidental one. Sorting lives in `src/utils/collections.ts`
and is covered by `tests/collections.test.ts`.

## Layout

Both footers sit in one bottom-pinned group. A lone `mt-auto` pins its
element to the viewport bottom, but two of them split the free space between
themselves — so the group carries the `mt-auto` and the site footer's own
goes inert.

## Notes

`SectionFooter` and `ArrowLink` are styled with Tailwind utilities rather
than scoped CSS, and CLAUDE.md now records that preference along with the
reasons each surviving `<style>` block in the repo earns its place.
