### PR TITLE
Publish notes by DMing a Telegram bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ _site
 
 # git worktrees
 .worktrees/
+
+# Local Netlify folder
+.netlify

--- a/netlify/functions/telegram-webhook.mts
+++ b/netlify/functions/telegram-webhook.mts
@@ -1,0 +1,98 @@
+import { Buffer } from "node:buffer";
+import {
+  buildNote,
+  type NoteFile,
+  type TelegramMessage,
+} from "../../src/utils/telegram-note";
+
+export const config = { path: "/api/telegram-webhook" };
+
+/**
+ * Publishes Telegram DMs sent to the notes bot as entries in posts/notes/.
+ *
+ * Flow: Telegram POSTs every update here (registered via setWebhook with a
+ * secret_token). We verify the secret header, drop anything not a plain text
+ * DM from the allowlisted user, convert it to a note file, and commit it to
+ * the repo via the GitHub Contents API — Netlify then rebuilds the site from
+ * that commit like any other push.
+ *
+ * Ignored updates still return 200: any other status makes Telegram retry
+ * the same update for up to 24h.
+ */
+export default async (req: Request): Promise<Response> => {
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+  const secret = process.env.TELEGRAM_WEBHOOK_SECRET;
+  if (!secret || req.headers.get("x-telegram-bot-api-secret-token") !== secret) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const update = await req.json();
+  const message: TelegramMessage | undefined = update.message;
+  if (!message) return skip("not a new message");
+  if (String(message.from?.id) !== process.env.TELEGRAM_ALLOWED_USER_ID) {
+    return skip("sender not allowlisted");
+  }
+
+  const note = buildNote(message, process.env.NOTES_TZ ?? "Asia/Kolkata");
+  if (!note) {
+    await reply(message, "Skipped: only plain-text messages become notes.");
+    return skip("no text");
+  }
+
+  const path = await commitNote(note, message.message_id);
+  await reply(message, `Published ${path} — the site is rebuilding.`);
+  return Response.json({ ok: true, path });
+};
+
+const skip = (reason: string) => Response.json({ ok: true, skipped: reason });
+
+async function commitNote(note: NoteFile, messageId: number): Promise<string> {
+  const put = async (path: string) =>
+    fetch(
+      `https://api.github.com/repos/${process.env.GITHUB_REPO}/contents/${path}`,
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+          "User-Agent": "tanvibhakta-notes-webhook",
+        },
+        body: JSON.stringify({
+          message: `note: publish from telegram`,
+          content: Buffer.from(note.content).toString("base64"),
+          branch: "main",
+        }),
+      },
+    );
+
+  let path = `posts/notes/${note.filename}`;
+  let res = await put(path);
+  if (res.status === 422) {
+    // Filename taken (two notes in the same minute, or a Telegram retry
+    // after a partial failure). The message_id suffix is deterministic per
+    // message, so retries converge instead of multiplying.
+    path = `posts/notes/${note.filename.replace(/\.md$/, `-${messageId}.md`)}`;
+    res = await put(path);
+  }
+  if (!res.ok) {
+    throw new Error(`GitHub commit failed: ${res.status} ${await res.text()}`);
+  }
+  return path;
+}
+
+// Confirmation back to the sender; best-effort, never fails the publish.
+async function reply(message: TelegramMessage, text: string): Promise<void> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token || !message.chat) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: message.chat.id, text }),
+    });
+  } catch {
+    // Publishing succeeded; a lost confirmation is not worth a retry loop.
+  }
+}

--- a/netlify/functions/telegram-webhook.mts
+++ b/netlify/functions/telegram-webhook.mts
@@ -41,9 +41,23 @@ export default async (req: Request): Promise<Response> => {
     return skip("no text");
   }
 
-  const path = await commitNote(note, message.message_id);
-  await reply(message, `Published ${path} — the site is rebuilding.`);
-  return Response.json({ ok: true, path });
+  // Failures ack with 200 + an error reply instead of a 500: a 500 makes
+  // Telegram re-deliver for up to 24h, spamming an error reply per retry
+  // and risking a surprise late publish after the sender has already
+  // resent. Telling the sender and letting them resend keeps one message
+  // ↔ one note.
+  try {
+    const path = await commitNote(note, message.message_id);
+    await reply(message, `Published ${path} — the site is rebuilding.`);
+    return Response.json({ ok: true, path });
+  } catch (error) {
+    console.error("telegram-webhook publish failed:", error);
+    await reply(
+      message,
+      `❌ Not published — ${error instanceof Error ? error.message : "unknown error"}. Nothing was saved; resend the message to retry.`,
+    );
+    return Response.json({ ok: false, error: "publish failed" });
+  }
 };
 
 const skip = (reason: string) => Response.json({ ok: true, skipped: reason });

--- a/src/utils/telegram-entities.ts
+++ b/src/utils/telegram-entities.ts
@@ -1,0 +1,201 @@
+/**
+ * Converts Telegram Bot API message text + MessageEntity annotations into
+ * CommonMark/GFM markdown suitable for committing as site content.
+ *
+ * Tree construction adapted from @telegraf/entity (MIT © 2023 Feathers
+ * Studio). The serializer deliberately targets standard markdown, NOT
+ * Telegram's MarkdownV2 dialect: minimal escaping, `**bold**`, GFM
+ * strikethrough, fenced code blocks, and inline HTML where CommonMark has
+ * no equivalent (underline).
+ *
+ * Entity offsets/lengths are UTF-16 code units — which is exactly how
+ * JavaScript strings are indexed, so plain .slice() is correct even for
+ * text containing astral-plane emoji.
+ */
+
+export interface TelegramMessageEntity {
+  type: string;
+  offset: number;
+  length: number;
+  url?: string;
+  language?: string;
+  user?: { id: number; first_name?: string };
+  custom_emoji_id?: string;
+}
+
+interface EntityNode extends TelegramMessageEntity {
+  text: string;
+  children: TreeNode[];
+}
+
+type TreeNode = string | EntityNode;
+
+// Entity types whose visible text already renders correctly and must not be
+// escaped (a backslash inside a URL or @mention would corrupt it).
+const RAW_TYPES = new Set([
+  "url",
+  "mention",
+  "hashtag",
+  "cashtag",
+  "bot_command",
+  "email",
+  "phone_number",
+]);
+
+// Telegram splits overlapping formats into adjacent entities of the same
+// type; these are the wrapper types where "**co****ming**" artifacts would
+// otherwise appear.
+const MERGEABLE_TYPES = new Set([
+  "bold",
+  "italic",
+  "underline",
+  "strikethrough",
+  "spoiler",
+]);
+
+export function entitiesToMarkdown(
+  text: string,
+  entities: TelegramMessageEntity[] = [],
+): string {
+  const sorted = [...entities].sort(
+    (a, b) => a.offset - b.offset || b.length - a.length,
+  );
+  return serialize(mergeAdjacent(toTree(text, sorted, 0, text.length)));
+}
+
+// Telegram guarantees entities are properly nested or disjoint, so a
+// containment check against the parent's end is enough to collect children.
+function toTree(
+  text: string,
+  entities: TelegramMessageEntity[],
+  offset: number,
+  upto: number,
+): TreeNode[] {
+  const nodes: TreeNode[] = [];
+  let last = offset;
+  let i = 0;
+  while (i < entities.length) {
+    const entity = entities[i];
+    if (last < entity.offset) {
+      nodes.push(text.slice(last, entity.offset));
+    }
+    const end = entity.offset + entity.length;
+    const children: TelegramMessageEntity[] = [];
+    for (let j = i + 1; j < entities.length; j++) {
+      if (entities[j].offset + entities[j].length > end) break;
+      children.push(entities[j]);
+    }
+    nodes.push({
+      ...entity,
+      text: text.slice(entity.offset, end),
+      children: toTree(text, children, entity.offset, end),
+    });
+    last = end;
+    i += children.length + 1;
+  }
+  if (last < upto) {
+    const tail = text.slice(last, upto);
+    if (tail) nodes.push(tail);
+  }
+  return nodes;
+}
+
+function mergeAdjacent(nodes: TreeNode[]): TreeNode[] {
+  const out: TreeNode[] = [];
+  for (const node of nodes) {
+    const prev = out[out.length - 1];
+    if (
+      typeof node !== "string" &&
+      prev !== undefined &&
+      typeof prev !== "string" &&
+      prev.type === node.type &&
+      prev.offset + prev.length === node.offset &&
+      MERGEABLE_TYPES.has(node.type)
+    ) {
+      prev.length += node.length;
+      prev.text += node.text;
+      prev.children = mergeAdjacent([...prev.children, ...node.children]);
+    } else if (typeof node === "string") {
+      out.push(node);
+    } else {
+      out.push({ ...node, children: mergeAdjacent(node.children) });
+    }
+  }
+  return out;
+}
+
+function serialize(nodes: TreeNode[]): string {
+  let out = "";
+  for (const node of nodes) {
+    out += typeof node === "string" ? escapeText(node) : serializeNode(node);
+  }
+  return out;
+}
+
+function serializeNode(node: EntityNode): string {
+  switch (node.type) {
+    case "bold":
+      return wrapEmphasis(serialize(node.children), "**");
+    case "italic":
+      return wrapEmphasis(serialize(node.children), "*");
+    case "strikethrough":
+      return wrapEmphasis(serialize(node.children), "~~");
+    case "underline":
+      return `<u>${serialize(node.children)}</u>`;
+    case "code":
+      return codeSpan(node.text);
+    case "pre":
+      return preBlock(node.text, node.language ?? "");
+    case "text_link":
+      return `[${serialize(node.children)}](${node.url ?? ""})`;
+    case "blockquote":
+    case "expandable_blockquote":
+      return serialize(node.children)
+        .split("\n")
+        .map((line) => (line ? `> ${line}` : ">"))
+        .join("\n");
+    default:
+      // Raw types render as-is; spoiler/text_mention/custom_emoji have no
+      // markdown equivalent and degrade to their visible text.
+      return RAW_TYPES.has(node.type) ? node.text : serialize(node.children);
+  }
+}
+
+// CommonMark flanking rules reject emphasis whose content starts/ends with
+// whitespace ("**ab **" is literal asterisks), so shift it outside.
+function wrapEmphasis(inner: string, delim: string): string {
+  const [, lead, core, trail] = inner.match(/^(\s*)([\s\S]*?)(\s*)$/)!;
+  if (!core) return inner;
+  return `${lead}${delim}${core}${delim}${trail}`;
+}
+
+function codeSpan(content: string): string {
+  const longestRun = (content.match(/`+/g) ?? []).reduce(
+    (max, run) => Math.max(max, run.length),
+    0,
+  );
+  const fence = "`".repeat(longestRun + 1);
+  const pad = content.startsWith("`") || content.endsWith("`") ? " " : "";
+  return `${fence}${pad}${content}${pad}${fence}`;
+}
+
+function preBlock(content: string, language: string): string {
+  const longestRun = (content.match(/`{3,}/g) ?? []).reduce(
+    (max, run) => Math.max(max, run.length),
+    2,
+  );
+  const fence = "`".repeat(longestRun + 1);
+  return `${fence}${language}\n${content.replace(/\n$/, "")}\n${fence}`;
+}
+
+// Escape only what CommonMark actually assigns meaning to. Inline specials
+// are escaped everywhere; block markers (headings, lists, quotes) only
+// where they'd trigger: at the start of a line, followed by the syntax
+// they need. Telegram messages are plain text plus entities, so any such
+// character the author typed was meant literally.
+function escapeText(text: string): string {
+  return text
+    .replace(/[\\*_[\]<`]/g, (ch) => `\\${ch}`)
+    .replace(/^(\s*)(>|#{1,6}(?= )|[-+](?= ))/gm, "$1\\$2")
+    .replace(/^(\s*\d+)\.(?= )/gm, "$1\\.");
+}

--- a/src/utils/telegram-note.ts
+++ b/src/utils/telegram-note.ts
@@ -1,0 +1,56 @@
+import {
+  entitiesToMarkdown,
+  type TelegramMessageEntity,
+} from "./telegram-entities";
+
+export interface TelegramMessage {
+  message_id: number;
+  date: number; // Unix epoch seconds, UTC
+  text?: string;
+  entities?: TelegramMessageEntity[];
+  from?: { id: number };
+  chat?: { id: number; type: string };
+}
+
+export interface NoteFile {
+  filename: string;
+  content: string;
+}
+
+/**
+ * Shapes a Telegram message into a note file matching the conventions of
+ * scripts/new-content.ts: filename `YYYY-MM-DD-HHmm.md`, frontmatter holding
+ * only a naive local wall-clock `publishedOn` (no offset — the site displays
+ * it verbatim), body converted from Telegram entities to markdown.
+ */
+export function buildNote(
+  message: TelegramMessage,
+  timeZone: string,
+): NoteFile | null {
+  if (!message.text?.trim()) return null;
+  const timestamp = wallClockTimestamp(message.date, timeZone);
+  const body = entitiesToMarkdown(message.text, message.entities);
+  return {
+    filename: `${timestamp.slice(0, 10)}-${timestamp.slice(11, 16).replace(":", "")}.md`,
+    content: `---\npublishedOn: ${timestamp}\n---\n\n${body}\n`,
+  };
+}
+
+// "YYYY-MM-DDTHH:mm:ss" as read off a clock in `timeZone`.
+function wallClockTimestamp(epochSeconds: number, timeZone: string): string {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    })
+      .formatToParts(new Date(epochSeconds * 1000))
+      .map((p) => [p.type, p.value]),
+  );
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}`;
+}

--- a/tests/telegram-entities.test.ts
+++ b/tests/telegram-entities.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "vitest";
+import {
+  entitiesToMarkdown,
+  type TelegramMessageEntity,
+} from "../src/utils/telegram-entities";
+
+// Offsets/lengths in these fixtures are UTF-16 code units, exactly as the
+// Telegram Bot API delivers them.
+const e = (
+  type: string,
+  offset: number,
+  length: number,
+  extra: Partial<TelegramMessageEntity> = {},
+): TelegramMessageEntity => ({ type, offset, length, ...extra });
+
+describe("plain text", () => {
+  test("passes through text without entities", () => {
+    expect(entitiesToMarkdown("hello world")).toBe("hello world");
+  });
+
+  test("escapes markdown specials even when there are no entities", () => {
+    // @telegraf/entity issue #13: their zero-entity path skips escaping.
+    expect(entitiesToMarkdown("5 * 3 = *15*")).toBe("5 \\* 3 = \\*15\\*");
+  });
+
+  test("escapes link-like brackets", () => {
+    expect(entitiesToMarkdown("[not](a-link)")).toBe("\\[not\\](a-link)");
+  });
+
+  test("escapes block-level markers at line starts", () => {
+    expect(entitiesToMarkdown("> quoted\n- item\n1. numbered\n# heading")).toBe(
+      "\\> quoted\n\\- item\n1\\. numbered\n\\# heading",
+    );
+  });
+});
+
+describe("inline formatting", () => {
+  test("bold", () => {
+    expect(entitiesToMarkdown("hello world", [e("bold", 6, 5)])).toBe(
+      "hello **world**",
+    );
+  });
+
+  test("italic", () => {
+    expect(entitiesToMarkdown("hello world", [e("italic", 6, 5)])).toBe(
+      "hello *world*",
+    );
+  });
+
+  test("strikethrough uses GFM tildes", () => {
+    expect(entitiesToMarkdown("hello world", [e("strikethrough", 6, 5)])).toBe(
+      "hello ~~world~~",
+    );
+  });
+
+  test("underline falls back to inline HTML", () => {
+    expect(entitiesToMarkdown("hello world", [e("underline", 6, 5)])).toBe(
+      "hello <u>world</u>",
+    );
+  });
+
+  test("spoiler degrades to plain text", () => {
+    expect(entitiesToMarkdown("secret: gift", [e("spoiler", 8, 4)])).toBe(
+      "secret: gift",
+    );
+  });
+
+  test("offsets index correctly past astral-plane emoji", () => {
+    // "😀" is two UTF-16 code units, so "hi" starts at offset 3.
+    expect(entitiesToMarkdown("😀 hi", [e("bold", 3, 2)])).toBe("😀 **hi**");
+  });
+
+  test("nested entities serialize inside-out", () => {
+    expect(
+      entitiesToMarkdown("hello world", [e("bold", 0, 11), e("italic", 6, 5)]),
+    ).toBe("**hello *world***");
+  });
+
+  test("trailing whitespace moves outside emphasis delimiters", () => {
+    // CommonMark flanking rules: "**ab cd **" is not emphasis.
+    expect(entitiesToMarkdown("ab cd end", [e("bold", 0, 6)])).toBe(
+      "**ab cd** end",
+    );
+  });
+
+  test("adjacent same-type entities merge into one span", () => {
+    // Telegram splits overlapping formats into adjacent entities;
+    // naive output "**co****ming**" is broken CommonMark.
+    expect(
+      entitiesToMarkdown("coming", [
+        e("bold", 0, 2),
+        e("bold", 2, 4),
+        e("italic", 2, 4),
+      ]),
+    ).toBe("**co*ming***");
+  });
+});
+
+describe("links", () => {
+  test("text_link becomes an inline link", () => {
+    expect(
+      entitiesToMarkdown("click here", [
+        e("text_link", 6, 4, { url: "https://example.com" }),
+      ]),
+    ).toBe("click [here](https://example.com)");
+  });
+
+  test("bare url entity is left raw, not escaped", () => {
+    expect(entitiesToMarkdown("see https://a_b.com", [e("url", 4, 15)])).toBe(
+      "see https://a_b.com",
+    );
+  });
+
+  test("mention is left raw, not escaped", () => {
+    expect(entitiesToMarkdown("@user_name", [e("mention", 0, 10)])).toBe(
+      "@user_name",
+    );
+  });
+
+  test("text_mention degrades to plain text", () => {
+    expect(
+      entitiesToMarkdown("hi Tanvi", [
+        e("text_mention", 3, 5, { user: { id: 42 } }),
+      ]),
+    ).toBe("hi Tanvi");
+  });
+});
+
+describe("code", () => {
+  test("code span", () => {
+    expect(entitiesToMarkdown("run npm test now", [e("code", 4, 8)])).toBe(
+      "run `npm test` now",
+    );
+  });
+
+  test("code span content is never backslash-escaped", () => {
+    expect(entitiesToMarkdown("a*b_c", [e("code", 0, 5)])).toBe("`a*b_c`");
+  });
+
+  test("code span containing backticks gets a longer fence", () => {
+    expect(entitiesToMarkdown("a `b` c", [e("code", 0, 7)])).toBe(
+      "``a `b` c``",
+    );
+  });
+
+  test("pre becomes a fenced block with language", () => {
+    expect(
+      entitiesToMarkdown("const x = 1;", [e("pre", 0, 12, { language: "js" })]),
+    ).toBe("```js\nconst x = 1;\n```");
+  });
+
+  test("pre without language", () => {
+    expect(entitiesToMarkdown("plain block", [e("pre", 0, 11)])).toBe(
+      "```\nplain block\n```",
+    );
+  });
+});
+
+describe("blocks", () => {
+  test("blockquote prefixes every line", () => {
+    expect(entitiesToMarkdown("line1\nline2", [e("blockquote", 0, 11)])).toBe(
+      "> line1\n> line2",
+    );
+  });
+
+  test("custom_emoji degrades to its fallback emoji text", () => {
+    expect(
+      entitiesToMarkdown("hi 😊", [
+        e("custom_emoji", 3, 2, { custom_emoji_id: "5368324170671202286" }),
+      ]),
+    ).toBe("hi 😊");
+  });
+});

--- a/tests/telegram-note.test.ts
+++ b/tests/telegram-note.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { buildNote, type TelegramMessage } from "../src/utils/telegram-note";
+
+// Telegram delivers message.date as Unix epoch seconds (UTC). Notes store a
+// naive local wall-clock timestamp, so all fixtures pin timeZone explicitly.
+const TZ = "Asia/Kolkata"; // UTC+05:30
+
+const msg = (overrides: Partial<TelegramMessage>): TelegramMessage => ({
+  message_id: 7,
+  date: Date.UTC(2026, 5, 21, 6, 30, 0) / 1000, // 12:00:00 IST
+  text: "hello",
+  ...overrides,
+});
+
+describe("buildNote", () => {
+  test("derives filename from wall-clock time in the given timezone", () => {
+    expect(buildNote(msg({}), TZ)?.filename).toBe("2026-06-21-1200.md");
+  });
+
+  test("frontmatter carries the full wall-clock timestamp", () => {
+    expect(buildNote(msg({}), TZ)?.content).toBe(
+      "---\npublishedOn: 2026-06-21T12:00:00\n---\n\nhello\n",
+    );
+  });
+
+  test("body is entity-converted markdown", () => {
+    const note = buildNote(
+      msg({
+        text: "hello world",
+        entities: [{ type: "bold", offset: 6, length: 5 }],
+      }),
+      TZ,
+    );
+    expect(note?.content).toContain("\n\nhello **world**\n");
+  });
+
+  test("returns null for messages without text", () => {
+    expect(buildNote(msg({ text: undefined }), TZ)).toBeNull();
+  });
+
+  test("returns null for whitespace-only text", () => {
+    expect(buildNote(msg({ text: "  \n " }), TZ)).toBeNull();
+  });
+
+  test("midnight formats as 00, not 24", () => {
+    // 18:35:00 UTC = 00:05:00 IST next day
+    const note = buildNote(
+      msg({ date: Date.UTC(2026, 5, 21, 18, 35, 0) / 1000 }),
+      TZ,
+    );
+    expect(note?.filename).toBe("2026-06-22-0005.md");
+    expect(note?.content).toContain("publishedOn: 2026-06-22T00:05:00");
+  });
+});


### PR DESCRIPTION
## What

A Netlify function (`/api/telegram-webhook`) that turns Telegram DMs sent to @NotesTanviBhaktaInBot into published notes: it converts the message's formatting entities to CommonMark, writes a `posts/notes/YYYY-MM-DD-HHmm.md` file matching the `new-content.ts` conventions (wall-clock `publishedOn` in `NOTES_TZ`), and commits it via the GitHub Contents API — Netlify then rebuilds as with any push.

## Security model

- Telegram authenticates itself via the `X-Telegram-Bot-Api-Secret-Token` header (set at `setWebhook` time); wrong/missing secret → 403.
- Only messages from the allowlisted user ID publish; everything else is acked with 200 and skipped (any non-200 makes Telegram retry for 24h).
- Same-minute filename collisions and Telegram retries fall back to a deterministic `-<message_id>` suffix, so retries converge instead of duplicating notes.

## Entity → markdown converter

Tree construction adapted from `@telegraf/entity` (MIT, attributed). Deliberately emits CommonMark/GFM rather than Telegram's MarkdownV2 dialect: minimal escaping (inline specials everywhere, block markers only at line starts), merges Telegram's split adjacent same-type entities, moves flanking whitespace outside emphasis delimiters, `<u>` for underline, raw passthrough for URLs/mentions so escaping can't corrupt them.

## Config (already set on the Netlify site)

`TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, `TELEGRAM_ALLOWED_USER_ID`, `GITHUB_TOKEN` (fine-grained PAT, contents-only), `GITHUB_REPO`, `NOTES_TZ`.

The webhook gets registered with Telegram only after this deploys (registering earlier would queue deliveries against a 404).

## Tests

30 vitest cases covering the converter (UTF-16 offsets past emoji, nesting, escaping, code fences, blockquotes, adjacency merge, flanking whitespace) and the note builder (timezone wall-clock conversion, midnight h23 edge, null on non-text). Pre-commit ran prettier + full suite + production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)