### PR TITLE
Add site-wide footer to every page except the homepage

### DIFF
--- a/docs/plans/2026-07-19-site-footer-design.md
+++ b/docs/plans/2026-07-19-site-footer-design.md
@@ -1,0 +1,39 @@
+# Site-wide footer
+
+## Context
+
+The site has a three-layer footer system:
+
+1. **Homepage `Footer.astro`** — the original mailto + `rel="me"` IndieAuth
+   link. Homepage-only, unchanged by this work.
+2. **`SectionFooter.astro`** (PR #112) — per-post prev/next navigation within
+   a section. Lives inside `EntryPage`, i.e. inside the article.
+3. **`SiteFooter.astro`** (this design) — a site-wide sign-off on every page
+   except the homepage.
+
+## Decisions
+
+- **Job: a quiet door, not a directory.** The nav deliberately holds only
+  three items while Poetry, Digital Garden, Tags, Subscribe, and Sitemap stay
+  semi-hidden ("the inquisitive discerning reader's browsing experience").
+  Enumerating every page in the footer would undo that choice. Instead the
+  footer offers one doorway — `/sitemap` — plus identity essentials.
+- **Contents:** © 2016–{current year} Tanvi Bhakta · sitemap · subscribe ·
+  me@tanvibhakta.in. The year range starts at the repo's first commit (Sept 2016) and the upper bound is computed at build time, so it never goes stale
+  (the site rebuilds on every publish).
+- **Form: one quiet line.** Centered, small-caps, 0.8rem, ~60% opacity,
+  middot-separated, flex-wrap for narrow screens, no border — the same
+  visual register as `.post-meta` and `.tag`. It reads as a sign-off, not a
+  section.
+- **Mount point: `ProseLayout`, after the `<article>`.** Every page except
+  the homepage renders through ProseLayout, so "site-wide except home" falls
+  out with zero conditional logic. ProseLayout's body is already
+  `min-h-screen flex flex-col`, so `margin-top: auto` pins the footer to the
+  viewport bottom on short pages and lets it flow after long posts.
+- **Registry, not copies:** the subscribe href comes from
+  `STANDALONE_PAGES`; `/sitemap` is hardcoded because the sitemap is itself
+  the index and belongs to no enumerated set.
+- **PR #112 interplay:** SectionFooter arrives through ProseLayout's slot
+  (inside the article); SiteFooter mounts after it. Different files, no
+  conflict, and reading order on a post is content → prev/next → tags →
+  site footer.

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,0 +1,44 @@
+---
+// Site-wide sign-off: one quiet line on every page except the homepage,
+// which keeps its own Footer. Third layer of the footer system, alongside
+// the homepage Footer and the per-post SectionFooter (PR #112).
+import { STANDALONE_PAGES } from "../content.config";
+
+// Build-time year; the site rebuilds on every publish so it never goes stale.
+const year = new Date().getFullYear();
+---
+
+<footer class="site-footer not-prose">
+  <span>© 2016–{year} Tanvi Bhakta</span>
+  <span aria-hidden="true">·</span>
+  <a href="/sitemap">sitemap</a>
+  <span aria-hidden="true">·</span>
+  <a href={STANDALONE_PAGES.subscribe.href}>subscribe</a>
+  <span aria-hidden="true">·</span>
+  <a href="mailto:Tanvi Bhakta <me@tanvibhakta.in>">me@tanvibhakta.in</a>
+</footer>
+
+<style>
+  /* Same quiet-metadata register as .post-meta and .tag in ProseLayout. */
+  .site-footer {
+    margin-top: auto;
+    padding: 3rem 1rem 1.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    font-variant: small-caps;
+    letter-spacing: 0.03em;
+    opacity: 0.6;
+  }
+
+  .site-footer a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .site-footer a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -8,37 +8,31 @@ import { STANDALONE_PAGES } from "../content.config";
 const year = new Date().getFullYear();
 ---
 
-<footer class="site-footer not-prose">
-  <span>© 2016–{year} Tanvi Bhakta</span>
+<footer
+  class="not-prose mt-auto flex flex-wrap justify-center gap-2 px-4 pt-12 pb-6 text-sm tracking-wide opacity-60 [font-variant:small-caps]"
+>
+  <span>
+    © 2016–{year}
+    <a href="/" class="text-inherit no-underline hover:underline">
+      tanvi bhakta
+    </a>
+  </span>
   <span aria-hidden="true">·</span>
-  <a href="/sitemap">sitemap</a>
+  <a href="/sitemap" class="text-inherit no-underline hover:underline">
+    sitemap
+  </a>
   <span aria-hidden="true">·</span>
-  <a href={STANDALONE_PAGES.subscribe.href}>subscribe</a>
+  <a
+    href={STANDALONE_PAGES.subscribe.href}
+    class="text-inherit no-underline hover:underline"
+  >
+    subscribe
+  </a>
   <span aria-hidden="true">·</span>
-  <a href="mailto:Tanvi Bhakta <me@tanvibhakta.in>">me@tanvibhakta.in</a>
+  <a
+    href="mailto:Tanvi Bhakta <me@tanvibhakta.in>"
+    class="text-inherit no-underline hover:underline"
+  >
+    me@tanvibhakta.in
+  </a>
 </footer>
-
-<style>
-  /* Same quiet-metadata register as .post-meta and .tag in ProseLayout. */
-  .site-footer {
-    margin-top: auto;
-    padding: 3rem 1rem 1.5rem;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.5rem;
-    font-size: 0.8rem;
-    font-variant: small-caps;
-    letter-spacing: 0.03em;
-    opacity: 0.6;
-  }
-
-  .site-footer a {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .site-footer a:hover {
-    text-decoration: underline;
-  }
-</style>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -21,10 +21,14 @@ const links = [
 ---
 
 <footer
-  class="not-prose mt-auto flex flex-wrap justify-center gap-2 px-4 pt-12 pb-6 text-sm tracking-wide opacity-60 [font-variant:small-caps]"
+  class="not-prose mt-auto flex flex-wrap justify-center gap-2 px-4 pt-12 pb-6 text-sm md:text-base tracking-wide opacity-60 [font-variant:small-caps]"
 >
   <span>
-    © 2016–{year}
+    {
+      /* Digits aren't letters, so small-caps leaves them full-height; the
+        served Open Sans lacks oldstyle-nums, so scale them optically. */
+    }
+    © <span class="text-[0.82em]">2016–{year}</span>
     <a href="/" class={LINK_CLASS}>tanvi bhakta</a>
   </span>
   {

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,7 +1,7 @@
 ---
 // Site-wide sign-off: one quiet line on every page except the homepage,
 // which keeps its own Footer. Third layer of the footer system, alongside
-// the homepage Footer and the per-post SectionFooter (PR #112).
+// the homepage Footer and the per-post SectionFooter
 import { STANDALONE_PAGES } from "../content.config";
 
 // Build-time year; the site rebuilds on every publish so it never goes stale.
@@ -9,8 +9,11 @@ const year = new Date().getFullYear();
 
 // Astro has no in-file subcomponents, so the footer's single link type is
 // defined once here and rendered by the one <a> in the template.
-const LINK_CLASS = "text-inherit no-underline hover:underline";
+// text-inherit needs ! because the unlayered `a` color in global.css
+// outranks Tailwind's layered utilities (same trick as Nav.astro).
+const LINK_CLASS = "text-inherit! no-underline hover:underline";
 const links = [
+  { href: "/", label: "tanvi bhakta" },
   { href: "/sitemap", label: "sitemap" },
   { href: STANDALONE_PAGES.subscribe.href, label: "subscribe" },
   {
@@ -21,16 +24,9 @@ const links = [
 ---
 
 <footer
-  class="not-prose mt-auto flex flex-wrap justify-center gap-2 px-4 pt-12 pb-6 text-sm md:text-base tracking-wide opacity-60 [font-variant:small-caps]"
+  class="not-prose mt-auto flex flex-wrap justify-center gap-2 px-4 pt-12 pb-6 text-sm md:text-base font-semibold md:tracking-wide opacity-60 [font-variant:small-caps]"
 >
-  <span>
-    {
-      /* Digits aren't letters, so small-caps leaves them full-height; the
-        served Open Sans lacks oldstyle-nums, so scale them optically. */
-    }
-    © <span class="text-[0.82em]">2016–{year}</span>
-    <a href="/" class={LINK_CLASS}>tanvi bhakta</a>
-  </span>
+  <span>© <span class="text-[0.82em]">2016–{year}</span></span>
   {
     links.map((link) => (
       <>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -6,6 +6,18 @@ import { STANDALONE_PAGES } from "../content.config";
 
 // Build-time year; the site rebuilds on every publish so it never goes stale.
 const year = new Date().getFullYear();
+
+// Astro has no in-file subcomponents, so the footer's single link type is
+// defined once here and rendered by the one <a> in the template.
+const LINK_CLASS = "text-inherit no-underline hover:underline";
+const links = [
+  { href: "/sitemap", label: "sitemap" },
+  { href: STANDALONE_PAGES.subscribe.href, label: "subscribe" },
+  {
+    href: "mailto:Tanvi Bhakta <me@tanvibhakta.in>",
+    label: "me@tanvibhakta.in",
+  },
+];
 ---
 
 <footer
@@ -13,26 +25,16 @@ const year = new Date().getFullYear();
 >
   <span>
     © 2016–{year}
-    <a href="/" class="text-inherit no-underline hover:underline">
-      tanvi bhakta
-    </a>
+    <a href="/" class={LINK_CLASS}>tanvi bhakta</a>
   </span>
-  <span aria-hidden="true">·</span>
-  <a href="/sitemap" class="text-inherit no-underline hover:underline">
-    sitemap
-  </a>
-  <span aria-hidden="true">·</span>
-  <a
-    href={STANDALONE_PAGES.subscribe.href}
-    class="text-inherit no-underline hover:underline"
-  >
-    subscribe
-  </a>
-  <span aria-hidden="true">·</span>
-  <a
-    href="mailto:Tanvi Bhakta <me@tanvibhakta.in>"
-    class="text-inherit no-underline hover:underline"
-  >
-    me@tanvibhakta.in
-  </a>
+  {
+    links.map((link) => (
+      <>
+        <span aria-hidden="true">·</span>
+        <a href={link.href} class={LINK_CLASS}>
+          {link.label}
+        </a>
+      </>
+    ))
+  }
 </footer>

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "./Layout.astro";
 import Nav from "../components/Nav.astro";
+import SiteFooter from "../components/SiteFooter.astro";
 import { shortenWeeknoteTitles, formatLongDate } from "../utils/date-helpers";
 
 const { frontmatter, category, readingTimeMinutes, hidePublishedOn, noindex } =
@@ -74,6 +75,7 @@ if (frontmatter?.title) {
       )
     }
   </article>
+  <SiteFooter />
 </Layout>
 
 <style>


### PR DESCRIPTION
## What

A new `SiteFooter.astro` — one quiet line, mounted in `ProseLayout` after the article, so it appears on every page except the homepage (which keeps its own `Footer.astro`):

> © 2016–2026 tanvi bhakta · sitemap · subscribe · me@tanvibhakta.in

## Design intent

- **A door, not a directory.** The nav's deliberate three-item tiering (and the semi-hidden page layer behind `/sitemap`) stays intact — the footer offers one doorway plus identity essentials, in the site's small-caps quiet-metadata register.
- **Zero conditional logic:** every non-home page already renders through ProseLayout, so mounting there gives "site-wide except home" for free.
- **No new copies of site structure:** subscribe href comes from `STANDALONE_PAGES`; `/sitemap` is hardcoded because the sitemap is itself the index.
- **Year range** starts at the repo's first commit (Sept 2016); upper bound computed at build time so it never goes stale.
- **Plays nice with #112:** SectionFooter arrives through ProseLayout's slot (inside the article); SiteFooter mounts after it. Different files, no conflict; reading order on a post is content → prev/next → tags → site footer.

Full design notes: `docs/plans/2026-07-19-site-footer-design.md`.

## Verification

- `pnpm typecheck`, `pnpm build` (130 pages), `pnpm test` (65/65, incl. internal-link crawler) all pass
- Built HTML spot-checked: footer present on /work, /blog, /tags, /subscribe, /sitemap; absent on /

🤖 Generated with [Claude Code](https://claude.com/claude-code)